### PR TITLE
Automatic tests on minimum rustc version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,9 @@ environment:
       RUST_VERSION: nightly
     - TARGET: x86_64-pc-windows-msvc
       RUST_VERSION: nightly
+    # Testing on oldest supported version of Rust
+    - TARGET: x86_64-pc-windows-msvc
+      RUST_VERSION: 1.26.0
 
 install:
   - ps: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,8 @@ environment:
     - TARGET: x86_64-pc-windows-msvc
 
     # Testing other channels
+    - TARGET: x86_64-pc-windows-msvc
+      RUST_VERSION: beta
     - TARGET: x86_64-pc-windows-gnu
       RUST_VERSION: nightly
     - TARGET: x86_64-pc-windows-msvc


### PR DESCRIPTION
To prevent dropping support for an older version of Rust without even noticing it it's good to always run tests towards the oldest supported version. This way one can easily see when compatibility is broken.

It's nothing wrong with bumping the minimum required version. But it should then also bump the major version number in the crate, so peoples builds don't start breaking randomly. And it should also be added to the changelog I think.

Funny enough our oldest supported version at the moment seems to be 1.26, which is the newest stable version. See these build logs for the errors on 1.25 for example: https://ci.appveyor.com/project/Mullvad/windows-service-rs/build/1.0.8/job/l8pq700041thrlvi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/2)
<!-- Reviewable:end -->
