### PR TITLE
Unify errors and handle errors in examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "windows-service"
 version = "0.1.0"
 description = "A crate that provides facilities for management and implementation of windows services"
+readme = "README.md"
 authors = ["Mullvad VPN <admin@mullvad.net>", "Andrej Mihajlov <and@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>"]
 keywords = ["windows", "service", "daemon"]
 categories = ["api-bindings"]

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ fn run_service(arguments: Vec<OsString>) -> windows_service::Result<()> {
     };
 
     // Tell the system that the service is running now
-    status_handle.set_service_status(next_status);
+    status_handle.set_service_status(next_status)?;
 
     // Do some work
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ fn my_service_main(arguments: Vec<OsString>) {
     // `service_dispatcher::start` from `main`.
 }
 
-fn main() {
+fn main() -> Result<(), windows_service::Error> {
     // Register generated `ffi_service_main` with the system and start the service, blocking
     // this thread until the service is stopped.
-    service_dispatcher::start("myservice", ffi_service_main).unwrap();
+    service_dispatcher::start("myservice", ffi_service_main)?;
+    Ok(())
 }
 ```
 
@@ -53,6 +54,12 @@ use windows_service::service::ServiceControl;
 use windows_service::service_control_handler::{self, ServiceControlHandlerResult};
 
 fn my_service_main(arguments: Vec<OsString>) {
+    if let Err(_e) = run_service(arguments) {
+        // Handle errors in some way.
+    }
+}
+
+fn run_service(arguments: Vec<OsString>) -> Result<(), windows_service::Error> {
     let event_handler = move |control_event| -> ServiceControlHandlerResult {
         match control_event {
             ServiceControl::Stop => {
@@ -66,7 +73,8 @@ fn my_service_main(arguments: Vec<OsString>) {
     };
 
     // Register system service event handler
-    let status_handle = service_control_handler::register("myservice", event_handler).unwrap();
+    let status_handle = service_control_handler::register("myservice", event_handler)?;
+    Ok(())
 }
 ```
 
@@ -106,6 +114,12 @@ use windows_service::service::{
 use windows_service::service_control_handler::{self, ServiceControlHandlerResult};
 
 fn my_service_main(arguments: Vec<OsString>) {
+    if let Err(_e) = run_service(arguments) {
+        // Handle error in some way.
+    }
+}
+
+fn run_service(arguments: Vec<OsString>) -> windows_service::Result<()> {
     let event_handler = move |control_event| -> ServiceControlHandlerResult {
         match control_event {
             ServiceControl::Stop | ServiceControl::Interrogate => {
@@ -116,8 +130,7 @@ fn my_service_main(arguments: Vec<OsString>) {
     };
 
     // Register system service event handler
-    let status_handle =
-        service_control_handler::register("my_service_name", event_handler).unwrap();
+    let status_handle = service_control_handler::register("my_service_name", event_handler)?;
 
     let next_status = ServiceStatus {
         // Should match the one from system service registry
@@ -138,8 +151,9 @@ fn my_service_main(arguments: Vec<OsString>) {
     status_handle.set_service_status(next_status);
 
     // Do some work
-}
 
+    Ok(())
+}
 ```
 
 Please refer to the "Service State Transitions" article on MSDN for more info:\

--- a/examples/install_service.rs
+++ b/examples/install_service.rs
@@ -2,7 +2,7 @@
 extern crate windows_service;
 
 #[cfg(windows)]
-fn main() {
+fn main() -> windows_service::Result<()> {
     use std::ffi::OsString;
     use windows_service::service::{
         ServiceAccess, ServiceErrorControl, ServiceInfo, ServiceStartType, ServiceType,
@@ -10,7 +10,7 @@ fn main() {
     use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
 
     let manager_access = ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE;
-    let service_manager = ServiceManager::local_computer(None::<&str>, manager_access).unwrap();
+    let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
 
     // This example installs the service defined in `examples/ping_service.rs`.
     // In the real world code you would set the executable path to point to your own binary
@@ -30,9 +30,8 @@ fn main() {
         account_name: None, // run as System
         account_password: None,
     };
-    let _service = service_manager
-        .create_service(service_info, ServiceAccess::empty())
-        .unwrap();
+    let _service = service_manager.create_service(service_info, ServiceAccess::empty())?;
+    Ok(())
 }
 
 #[cfg(not(windows))]

--- a/examples/uninstall_service.rs
+++ b/examples/uninstall_service.rs
@@ -2,28 +2,27 @@
 extern crate windows_service;
 
 #[cfg(windows)]
-fn main() {
+fn main() -> windows_service::Result<()> {
     use std::thread;
     use std::time::Duration;
     use windows_service::service::{ServiceAccess, ServiceState};
     use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
 
     let manager_access = ServiceManagerAccess::CONNECT;
-    let service_manager = ServiceManager::local_computer(None::<&str>, manager_access).unwrap();
+    let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
 
     let service_access = ServiceAccess::QUERY_STATUS | ServiceAccess::STOP | ServiceAccess::DELETE;
-    let service = service_manager
-        .open_service("ping_service", service_access)
-        .unwrap();
+    let service = service_manager.open_service("ping_service", service_access)?;
 
-    let service_status = service.query_status().unwrap();
+    let service_status = service.query_status()?;
     if service_status.current_state != ServiceState::Stopped {
-        service.stop().unwrap();
+        service.stop()?;
         // Wait for service to stop
         thread::sleep(Duration::from_secs(1));
     }
 
-    service.delete().unwrap();
+    service.delete()?;
+    Ok(())
 }
 
 #[cfg(not(windows))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@
 //!     };
 //!
 //!     // Tell the system that the service is running now
-//!     status_handle.set_service_status(next_status);
+//!     status_handle.set_service_status(next_status)?;
 //!
 //!     // Do some work
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,10 +39,11 @@
 //!     // `service_dispatcher::start` from `main`.
 //! }
 //!
-//! fn main() {
+//! fn main() -> Result<(), windows_service::Error> {
 //!     // Register generated `ffi_service_main` with the system and start the service, blocking
 //!     // this thread until the service is stopped.
-//!     service_dispatcher::start("myservice", ffi_service_main).unwrap();
+//!     service_dispatcher::start("myservice", ffi_service_main)?;
+//!     Ok(())
 //! }
 //! ```
 //!
@@ -59,6 +60,12 @@
 //! use windows_service::service_control_handler::{self, ServiceControlHandlerResult};
 //!
 //! fn my_service_main(arguments: Vec<OsString>) {
+//!     if let Err(_e) = run_service(arguments) {
+//!         // Handle errors in some way.
+//!     }
+//! }
+//!
+//! fn run_service(arguments: Vec<OsString>) -> Result<(), windows_service::Error> {
 //!     let event_handler = move |control_event| -> ServiceControlHandlerResult {
 //!         match control_event {
 //!             ServiceControl::Stop => {
@@ -72,7 +79,8 @@
 //!     };
 //!
 //!     // Register system service event handler
-//!     let status_handle = service_control_handler::register("myservice", event_handler).unwrap();
+//!     let status_handle = service_control_handler::register("myservice", event_handler)?;
+//!     Ok(())
 //! }
 //! ```
 //!
@@ -112,6 +120,12 @@
 //! use windows_service::service_control_handler::{self, ServiceControlHandlerResult};
 //!
 //! fn my_service_main(arguments: Vec<OsString>) {
+//!     if let Err(_e) = run_service(arguments) {
+//!         // Handle error in some way.
+//!     }
+//! }
+//!
+//! fn run_service(arguments: Vec<OsString>) -> windows_service::Result<()> {
 //!     let event_handler = move |control_event| -> ServiceControlHandlerResult {
 //!         match control_event {
 //!             ServiceControl::Stop | ServiceControl::Interrogate => {
@@ -122,8 +136,7 @@
 //!     };
 //!
 //!     // Register system service event handler
-//!     let status_handle =
-//!         service_control_handler::register("my_service_name", event_handler).unwrap();
+//!     let status_handle = service_control_handler::register("my_service_name", event_handler)?;
 //!
 //!     let next_status = ServiceStatus {
 //!         // Should match the one from system service registry
@@ -144,9 +157,9 @@
 //!     status_handle.set_service_status(next_status);
 //!
 //!     // Do some work
-//! }
 //!
-//! # fn main() {}
+//!     Ok(())
+//! }
 //! ```
 //!
 //! Please refer to the "Service State Transitions" article on MSDN for more info:\

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,9 @@
 
 #![cfg(windows)]
 
+// Because of how deeply error-chain recurse with this many error types.
+#![recursion_limit = "128"]
+
 #[macro_use]
 extern crate bitflags;
 #[macro_use]
@@ -168,6 +171,62 @@ extern crate widestring;
 extern crate winapi;
 
 pub use error_chain::ChainedError;
+
+error_chain! {
+    errors {
+        /// Invalid account name.
+        InvalidAccountName {
+            description("Invalid account name")
+        }
+        /// Invalid account password.
+        InvalidAccountPassword {
+            description("Invalid account password")
+        }
+        /// Invalid display name.
+        InvalidDisplayName {
+            description("Invalid display name")
+        }
+        /// Invalid database name.
+        InvalidDatabaseName {
+            description("Invalid database name")
+        }
+        /// Invalid executable path.
+        InvalidExecutablePath {
+            description("Invalid executable path")
+        }
+        /// Invalid launch arguments.
+        InvalidLaunchArgument {
+            description("Invalid launch argument")
+        }
+        /// Invalid machine name.
+        InvalidMachineName {
+            description("Invalid machine name")
+        }
+        /// Invalid service name.
+        InvalidServiceName {
+            description("Invalid service name")
+        }
+
+        /// Invalid raw representation of [`ServiceType`].
+        InvalidServiceType(raw_value: u32) {
+            description("Invalid service type value")
+            display("Invalid service type value: {}", raw_value)
+        }
+        /// Invalid raw representation of [`ServiceState`].
+        InvalidServiceState(raw_value: u32) {
+            description("Invalid service state")
+            display("Invalid service state value: {}", raw_value)
+        }
+        /// Invalid raw representation of [`ServiceControl`].
+        InvalidServiceControl(raw_value: u32) {
+            description("Invalid service control")
+            display("Invalid service control value: {}", raw_value)
+        }
+    }
+    foreign_links {
+        System(::std::io::Error) #[doc = "System call error"];
+    }
+}
 
 mod sc_handle;
 pub mod service;

--- a/src/service.rs
+++ b/src/service.rs
@@ -7,32 +7,7 @@ use winapi::shared::winerror::{ERROR_SERVICE_SPECIFIC_ERROR, NO_ERROR};
 use winapi::um::{winnt, winsvc};
 
 use sc_handle::ScHandle;
-
-mod errors {
-    error_chain! {
-        errors {
-            /// Invalid raw representation of [`ServiceType`].
-            InvalidServiceType(raw_value: u32) {
-                description("Invalid service type value")
-                display("Invalid service type value: {}", raw_value)
-            }
-            /// Invalid raw representation of [`ServiceState`].
-            InvalidServiceState(raw_value: u32) {
-                description("Invalid service state")
-                display("Invalid service state value: {}", raw_value)
-            }
-            /// Invalid raw representation of [`ServiceControl`].
-            InvalidServiceControl(raw_value: u32) {
-                description("Invalid service control")
-                display("Invalid service control value: {}", raw_value)
-            }
-        }
-        foreign_links {
-            System(::std::io::Error) #[doc = "System call error."];
-        }
-    }
-}
-pub use self::errors::*;
+use {ErrorKind, Result};
 
 /// Enum describing the types of Windows services.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/service_control_handler.rs
+++ b/src/service_control_handler.rs
@@ -72,15 +72,21 @@ impl ServiceControlHandlerResult {
 /// use windows_service::service::ServiceControl;
 /// use windows_service::service_control_handler::{self, ServiceControlHandlerResult};
 ///
-/// fn my_service_main(arguments: Vec<OsString>) {
+/// fn my_service_main(_arguments: Vec<OsString>) {
+///     if let Err(_e) = run_service() {
+///         // Handle errors...
+///     }
+/// }
+///
+/// fn run_service() -> windows_service::Result<()> {
 ///     let event_handler = move |control_event| -> ServiceControlHandlerResult {
 ///         match control_event {
 ///             ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
 ///             _ => ServiceControlHandlerResult::NotImplemented,
 ///         }
 ///     };
-///     let status_handle =
-///         service_control_handler::register("my_service_name", event_handler).unwrap();
+///     let status_handle = service_control_handler::register("my_service_name", event_handler)?;
+///     Ok(())
 /// }
 ///
 /// # fn main() {}

--- a/src/service_control_handler.rs
+++ b/src/service_control_handler.rs
@@ -5,21 +5,7 @@ use winapi::shared::winerror::{ERROR_CALL_NOT_IMPLEMENTED, NO_ERROR};
 use winapi::um::winsvc;
 
 use service::{ServiceControl, ServiceStatus};
-
-mod errors {
-    error_chain! {
-        errors {
-            /// Invalid service name.
-            InvalidServiceName {
-                description("Invalid service name")
-            }
-        }
-        foreign_links {
-            System(::std::io::Error) #[doc = "System call error."];
-        }
-    }
-}
-pub use self::errors::*;
+use {ErrorKind, Result, ResultExt};
 
 /// A struct that holds a unique token for updating the status of the corresponding service.
 #[derive(Debug, Clone, Copy)]

--- a/src/service_dispatcher.rs
+++ b/src/service_dispatcher.rs
@@ -1,22 +1,10 @@
 use std::ffi::{OsStr, OsString};
 use std::{io, ptr};
+
 use widestring::{WideCStr, WideCString};
 use winapi::um::winsvc;
 
-mod errors {
-    error_chain! {
-        errors {
-            /// Invalid service name.
-            InvalidServiceName {
-                description("Invalid service name")
-            }
-        }
-        foreign_links {
-            System(::std::io::Error) #[doc = "System call error."];
-        }
-    }
-}
-pub use self::errors::*;
+use {ErrorKind, Result, ResultExt};
 
 /// A macro to generate an entry point function (aka "service_main") for Windows service.
 ///

--- a/src/service_dispatcher.rs
+++ b/src/service_dispatcher.rs
@@ -73,10 +73,11 @@ macro_rules! define_windows_service {
 ///     // `service_dispatcher::start` from `main`.
 /// }
 ///
-/// fn main() {
+/// fn main() -> windows_service::Result<()> {
 ///     // Register generated `ffi_service_main` with the system and start the service, blocking
 ///     // this thread until the service is stopped.
-///     service_dispatcher::start("myservice", ffi_service_main).unwrap();
+///     service_dispatcher::start("myservice", ffi_service_main)?;
+///     Ok(())
 /// }
 /// ```
 ///

--- a/src/service_manager.rs
+++ b/src/service_manager.rs
@@ -114,24 +114,26 @@ impl ServiceManager {
     ///     ServiceAccess, ServiceErrorControl, ServiceInfo, ServiceStartType, ServiceType,
     /// };
     /// use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
-    /// let manager =
-    ///     ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CREATE_SERVICE).unwrap();
     ///
-    /// let my_service_info = ServiceInfo {
-    ///     name: OsString::from("my_service"),
-    ///     display_name: OsString::from("My service"),
-    ///     service_type: ServiceType::OwnProcess,
-    ///     start_type: ServiceStartType::OnDemand,
-    ///     error_control: ServiceErrorControl::Normal,
-    ///     executable_path: PathBuf::from(r"C:\path\to\my\service.exe"),
-    ///     launch_arguments: vec![],
-    ///     account_name: None, // run as System
-    ///     account_password: None,
-    /// };
+    /// fn main() -> windows_service::Result<()> {
+    ///     let manager =
+    ///         ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CREATE_SERVICE)?;
     ///
-    /// let my_service = manager
-    ///     .create_service(my_service_info, ServiceAccess::QUERY_STATUS)
-    ///     .unwrap();
+    ///     let my_service_info = ServiceInfo {
+    ///         name: OsString::from("my_service"),
+    ///         display_name: OsString::from("My service"),
+    ///         service_type: ServiceType::OwnProcess,
+    ///         start_type: ServiceStartType::OnDemand,
+    ///         error_control: ServiceErrorControl::Normal,
+    ///         executable_path: PathBuf::from(r"C:\path\to\my\service.exe"),
+    ///         launch_arguments: vec![],
+    ///         account_name: None, // run as System
+    ///         account_password: None,
+    ///     };
+    ///
+    ///     let my_service = manager.create_service(my_service_info, ServiceAccess::QUERY_STATUS)?;
+    ///     Ok(())
+    /// }
     /// ```
     pub fn create_service(
         &self,
@@ -201,11 +203,11 @@ impl ServiceManager {
     /// use windows_service::service::ServiceAccess;
     /// use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
     ///
-    /// let manager =
-    ///     ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT).unwrap();
-    /// let my_service = manager
-    ///     .open_service("my_service", ServiceAccess::QUERY_STATUS)
-    ///     .unwrap();
+    /// # fn main() -> windows_service::Result<()> {
+    /// let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)?;
+    /// let my_service = manager.open_service("my_service", ServiceAccess::QUERY_STATUS)?;
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     pub fn open_service<T: AsRef<OsStr>>(

--- a/src/service_manager.rs
+++ b/src/service_manager.rs
@@ -9,48 +9,7 @@ use sc_handle::ScHandle;
 use service::{Service, ServiceAccess, ServiceInfo};
 use shell_escape;
 
-mod errors {
-    error_chain! {
-        errors {
-            /// Invalid account name.
-            InvalidAccountName {
-                description("Invalid account name")
-            }
-            /// Invalid account password.
-            InvalidAccountPassword {
-                description("Invalid account password")
-            }
-            /// Invalid display name.
-            InvalidDisplayName {
-                description("Invalid display name")
-            }
-            /// Invalid database name.
-            InvalidDatabaseName {
-                description("Invalid database name")
-            }
-            /// Invalid executable path.
-            InvalidExecutablePath {
-                description("Invalid executable path")
-            }
-            /// Invalid launch arguments.
-            InvalidLaunchArgument {
-                description("Invalid launch argument")
-            }
-            /// Invalid machine name.
-            InvalidMachineName {
-                description("Invalid machine name")
-            }
-            /// Invalid service name.
-            InvalidServiceName {
-                description("Invalid service name")
-            }
-        }
-        foreign_links {
-            System(::std::io::Error) #[doc = "System call error."];
-        }
-    }
-}
-pub use self::errors::*;
+use {ErrorKind, Result, ResultExt};
 
 bitflags! {
     /// Flags describing access permissions for [`ServiceManager`].


### PR DESCRIPTION
At first I noticed that we had many different error types, and all had the `System(::std::io::Error) #[doc = "System call error."];` variant in it. Many of them also had other overlapping/equal error variants.

`error-chain` itself mandates having one crate-global error that the library exports. We have previously not followed this because we usually have very different errors in different modules, so it does not make much sense to group them etc. But here I felt they did overlap and it made a lot of sense to have one common `windows_service::Error`.

Then I also wanted to play around with the new functionality that `main` can return a `Result`. So I thought I'll try to incorporate that into the documentation in order to do "proper" error handling in the examples and documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/3)
<!-- Reviewable:end -->
