### PR TITLE
Make backtrace optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,8 @@ bitflags = "1.0.1"
 error-chain = "0.11"
 winapi = { version = "0.3", features = ["std", "winsvc", "winerror"] }
 widestring = "0.3.0"
+
+[features]
+default = ["backtrace", "error_chain_example_generated"]
+backtrace = ["error-chain/backtrace"]
+error_chain_example_generated = ["error-chain/example_generated"]


### PR DESCRIPTION
Reexport the default features from error-chain (backtrace, example_generated), so users of windows-service can disable them.

I'm pretty new at this so please let me know if this isn't a good way to go about it.