### PR TITLE
Upgrade error-chain to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ license = "MIT/Apache-2.0"
 
 [target.'cfg(windows)'.dependencies]
 bitflags = "1.0.1"
-error-chain = "0.11"
+error-chain = "0.12"
 winapi = { version = "0.3", features = ["std", "winsvc", "winerror"] }
 widestring = "0.3.0"


### PR DESCRIPTION
Getting error-chain up to speed just like all our other libs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/8)
<!-- Reviewable:end -->
