### PR TITLE
Add a NO_ERROR const to ServiceExitCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- A `ServiceExitCode::NO_ERROR` constant for easy access to the success value.
 
 
 ## [0.1.0] - 2018-06-04

--- a/src/service.rs
+++ b/src/service.rs
@@ -245,6 +245,9 @@ pub enum ServiceExitCode {
 }
 
 impl ServiceExitCode {
+    /// A `ServiceExitCode` indicating success, no errors.
+    pub const NO_ERROR: Self = ServiceExitCode::Win32(NO_ERROR);
+
     fn copy_to(&self, raw_service_status: &mut winsvc::SERVICE_STATUS) {
         match *self {
             ServiceExitCode::Win32(win32_error_code) => {
@@ -261,7 +264,7 @@ impl ServiceExitCode {
 
 impl Default for ServiceExitCode {
     fn default() -> Self {
-        ServiceExitCode::Win32(NO_ERROR)
+        Self::NO_ERROR
     }
 }
 


### PR DESCRIPTION
I personally feel that `ServiceExitCode::default()` feels a bit unclear what it means. It can of course be kept, and `NO_ERROR` is probably a very good default. But on top of that I would like to add a safe Rust constant that can be used and where the name is obvious.

So just for the exact same reason Windows defines the constant `NO_ERROR` and one is likely to use `return NO_ERROR` from their C code, it makes the equivalent sense to want to do `return ServiceExitCode::NO_ERROR` in Rust IMO.

Are there other, similar constants defined by Windows that makes sense to expose? Such as `ERROR` being just `1` or something?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/9)
<!-- Reviewable:end -->
