### PR TITLE
Reduce boxing and use static dispatch for event_handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - A `ServiceExitCode::NO_ERROR` constant for easy access to the success value.
 
+### Changed
+- Changed `service_control_handler::register` to accept an `FnMut` rather than just an `Fn` for the
+  `event_handler` closure.
+
 
 ## [0.1.0] - 2018-06-04
 ### Added


### PR DESCRIPTION
This started out with me wanting to pass a closure that could mutate itself on calls to it. So I set out to change the bound from `Fn` to `FnMut`. When doing that I realized we could get rid of the dynamic dispatch all together along with one layer of boxing. This reduces heap allocation and indirection with one level. As well as uses static dispatch for the callback.