### PR TITLE
Add `Service::start` and pin minimum winapi-rs to 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add support for specifying service dependencies when creating a service.
 - A `ServiceExitCode::NO_ERROR` constant for easy access to the success value.
+- Add `Service::start` for starting services programmatically.
 
 ### Changed
 - Changed `service_control_handler::register` to accept an `FnMut` rather than just an `Fn` for the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ license = "MIT/Apache-2.0"
 [target.'cfg(windows)'.dependencies]
 bitflags = "1.0.1"
 error-chain = "0.12"
-winapi = { version = "0.3", features = ["std", "winsvc", "winerror"] }
+winapi = { version = "0.3.5", features = ["std", "winsvc", "winerror"] }
 widestring = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,10 @@ error_chain! {
         InvalidServiceName {
             description("Invalid service name")
         }
-
+        /// Invalid start argument.
+        InvalidStartArgument {
+            description("Invalid start argument")
+        }
         /// Invalid raw representation of [`ServiceType`].
         InvalidServiceType(raw_value: u32) {
             description("Invalid service type value")

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,13 +1,14 @@
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 use std::time::Duration;
 use std::{io, mem};
 
+use widestring::WideCString;
 use winapi::shared::winerror::{ERROR_SERVICE_SPECIFIC_ERROR, NO_ERROR};
 use winapi::um::{winnt, winsvc};
 
 use sc_handle::ScHandle;
-use {ErrorKind, Result};
+use {ErrorKind, Result, ResultExt};
 
 /// Enum describing the types of Windows services.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -386,6 +387,46 @@ pub struct Service {
 impl Service {
     pub(crate) fn new(service_handle: ScHandle) -> Self {
         Service { service_handle }
+    }
+
+    /// Start the service.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use std::ffi::OsStr;
+    /// use windows_service::service::ServiceAccess;
+    /// use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+    ///
+    /// # fn main() -> windows_service::Result<()> {
+    /// let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)?;
+    /// let my_service = manager.open_service("my_service", ServiceAccess::START)?;
+    /// my_service.start(&[OsStr::new("Started from Rust!")])?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    pub fn start<S: AsRef<OsStr>>(&self, arguments: &[S]) -> Result<()> {
+        let wide_arguments = arguments
+            .iter()
+            .map(|s| WideCString::from_str(s).chain_err(|| ErrorKind::InvalidStartArgument))
+            .collect::<Result<Vec<WideCString>>>()?;
+        let mut raw_arguments: Vec<*const u16> =
+            wide_arguments.iter().map(|s| s.as_ptr()).collect();
+
+        let success = unsafe {
+            winsvc::StartServiceW(
+                self.service_handle.raw_handle(),
+                raw_arguments.len() as u32,
+                raw_arguments.as_mut_ptr(),
+            )
+        };
+
+        if success == 1 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error().into())
+        }
     }
 
     /// Stop the service.


### PR DESCRIPTION
This PR extends the `Service` interface with `Service::start(arguments: &[S])` that provides the programmatic way of starting windows services. Since the sys call to `StartServiceW` was added around time between 0.3.x and 0.3.5 I pinned the dependency target to 0.3.5.