### PR TITLE
Fix winapi result handling

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -535,7 +535,6 @@ impl Service {
     /// # Ok(())
     /// # }
     /// ```
-    ///
     pub fn start<S: AsRef<OsStr>>(&self, service_arguments: &[S]) -> Result<()> {
         let wide_service_arguments = service_arguments
             .iter()
@@ -552,10 +551,10 @@ impl Service {
             )
         };
 
-        if success == 1 {
-            Ok(())
-        } else {
+        if success == 0 {
             Err(io::Error::last_os_error().into())
+        } else {
+            Ok(())
         }
     }
 
@@ -570,20 +569,20 @@ impl Service {
         let success = unsafe {
             winsvc::QueryServiceStatus(self.service_handle.raw_handle(), &mut raw_status)
         };
-        if success == 1 {
-            ServiceStatus::from_raw(raw_status)
-        } else {
+        if success == 0 {
             Err(io::Error::last_os_error().into())
+        } else {
+            ServiceStatus::from_raw(raw_status)
         }
     }
 
     /// Delete the service from system registry.
     pub fn delete(self) -> io::Result<()> {
         let success = unsafe { winsvc::DeleteService(self.service_handle.raw_handle()) };
-        if success == 1 {
-            Ok(())
-        } else {
+        if success == 0 {
             Err(io::Error::last_os_error())
+        } else {
+            Ok(())
         }
     }
 
@@ -598,10 +597,10 @@ impl Service {
             )
         };
 
-        if success == 1 {
-            ServiceStatus::from_raw(raw_status).map_err(|err| err.into())
-        } else {
+        if success == 0 {
             Err(io::Error::last_os_error().into())
+        } else {
+            ServiceStatus::from_raw(raw_status).map_err(|err| err.into())
         }
     }
 

--- a/src/service_dispatcher.rs
+++ b/src/service_dispatcher.rs
@@ -34,7 +34,6 @@ use {ErrorKind, Result, ResultExt};
 ///
 /// # fn main() {}
 /// ```
-///
 #[macro_export]
 macro_rules! define_windows_service {
     ($function_name:ident, $service_main_handler:ident) => {
@@ -88,7 +87,6 @@ macro_rules! define_windows_service {
 ///     Ok(())
 /// }
 /// ```
-///
 pub fn start<T: AsRef<OsStr>>(
     service_name: T,
     service_main: extern "system" fn(u32, *mut *mut u16),

--- a/src/service_manager.rs
+++ b/src/service_manager.rs
@@ -35,11 +35,9 @@ impl ServiceManager {
     ///
     /// # Arguments
     ///
-    /// * `machine`  - The name of machine.
-    ///                Pass `None` to connect to local machine.
-    /// * `database` - The name of database to connect to.
-    ///                Pass `None` to connect to active database.
-    ///
+    /// * `machine` - The name of machine. Pass `None` to connect to local machine.
+    /// * `database` - The name of database to connect to. Pass `None` to connect to active
+    ///   database.
     fn new<M: AsRef<OsStr>, D: AsRef<OsStr>>(
         machine: Option<M>,
         database: Option<D>,
@@ -68,10 +66,9 @@ impl ServiceManager {
     ///
     /// # Arguments
     ///
-    /// * `database`       - The name of database to connect to.
-    ///                      Pass `None` to connect to active database.
+    /// * `database` - The name of database to connect to. Pass `None` to connect to active
+    ///   database.
     /// * `request_access` - Desired access permissions.
-    ///
     pub fn local_computer<D: AsRef<OsStr>>(
         database: Option<D>,
         request_access: ServiceManagerAccess,
@@ -83,11 +80,10 @@ impl ServiceManager {
     ///
     /// # Arguments
     ///
-    /// * `machine`        - The name of remote machine.
-    /// * `database`       - The name of database to connect to.
-    ///                      Pass `None` to connect to active database.
+    /// * `machine` - The name of remote machine.
+    /// * `database` - The name of database to connect to. Pass `None` to connect to active
+    ///   database.
     /// * `request_access` - desired access permissions.
-    ///
     pub fn remote_computer<M: AsRef<OsStr>, D: AsRef<OsStr>>(
         machine: M,
         database: Option<D>,
@@ -100,10 +96,9 @@ impl ServiceManager {
     ///
     /// # Arguments
     ///
-    /// * `service_info`   - The service information that will be saved to the system services
-    ///                      registry.
-    /// * `service_access` - Desired access permissions for the returned [`Service`]
-    ///                      instance.
+    /// * `service_info` - The service information that will be saved to the system services
+    ///   registry.
+    /// * `service_access` - Desired access permissions for the returned [`Service`] instance.
     ///
     /// # Example
     ///
@@ -147,8 +142,8 @@ impl ServiceManager {
             .chain_err(|| ErrorKind::InvalidDisplayName)?;
         let account_name =
             to_wide(service_info.account_name).chain_err(|| ErrorKind::InvalidAccountName)?;
-        let account_password =
-            to_wide(service_info.account_password).chain_err(|| ErrorKind::InvalidAccountPassword)?;
+        let account_password = to_wide(service_info.account_password)
+            .chain_err(|| ErrorKind::InvalidAccountPassword)?;
 
         // escape executable path and arguments and combine them into single command
         let executable_path = escape_wide(service_info.executable_path)
@@ -158,7 +153,8 @@ impl ServiceManager {
         launch_command_buffer.push(executable_path);
 
         for launch_argument in service_info.launch_arguments.iter() {
-            let wide = escape_wide(launch_argument).chain_err(|| ErrorKind::InvalidLaunchArgument)?;
+            let wide =
+                escape_wide(launch_argument).chain_err(|| ErrorKind::InvalidLaunchArgument)?;
 
             launch_command_buffer.push_str(" ");
             launch_command_buffer.push(wide);
@@ -207,7 +203,7 @@ impl ServiceManager {
     ///
     /// # Arguments
     ///
-    /// * `name`           - The service name.
+    /// * `name` - The service name.
     /// * `request_access` - Desired permissions for the returned [`Service`] instance.
     ///
     /// # Example
@@ -222,13 +218,13 @@ impl ServiceManager {
     /// # Ok(())
     /// # }
     /// ```
-    ///
     pub fn open_service<T: AsRef<OsStr>>(
         &self,
         name: T,
         request_access: ServiceAccess,
     ) -> Result<Service> {
-        let service_name = WideCString::from_str(name).chain_err(|| ErrorKind::InvalidServiceName)?;
+        let service_name =
+            WideCString::from_str(name).chain_err(|| ErrorKind::InvalidServiceName)?;
         let service_handle = unsafe {
             winsvc::OpenServiceW(
                 self.manager_handle.raw_handle(),


### PR DESCRIPTION
The error handling routine, when using the `winsvc::` family of functions, makes a false assumption that `1` is the only successful return code.

As per docs the *nonzero* code indicates success, so we should not assume that `1` is the only code returned upon success.

>If the function succeeds, the return value is nonzero.
>If the function fails, the return value is zero. To get extended error information, call GetLastError.

This PR remedies this issue by inversing the conditional check to check for failure first, since `0` is guaranteed to be returned on error. Even though we didn't stumble directly into any errors, it's still better to stick to what docs suggest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/15)
<!-- Reviewable:end -->
