### PR TITLE
Convert ServiceType to bitflags and add missing service types

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ fn run_service(arguments: Vec<OsString>) -> windows_service::Result<()> {
 
     let next_status = ServiceStatus {
         // Should match the one from system service registry
-        service_type: ServiceType::OwnProcess,
+        service_type: ServiceType::OWN_PROCESS,
         // The new state
         current_state: ServiceState::Running,
         // Accept stop events when running

--- a/examples/install_service.rs
+++ b/examples/install_service.rs
@@ -22,7 +22,7 @@ fn main() -> windows_service::Result<()> {
     let service_info = ServiceInfo {
         name: OsString::from("ping_service"),
         display_name: OsString::from("Ping service"),
-        service_type: ServiceType::OwnProcess,
+        service_type: ServiceType::OWN_PROCESS,
         start_type: ServiceStartType::OnDemand,
         error_control: ServiceErrorControl::Normal,
         executable_path: service_binary_path,

--- a/examples/ping_service.rs
+++ b/examples/ping_service.rs
@@ -43,7 +43,7 @@ mod ping_service {
 
 
     const SERVICE_NAME: &'static str = "ping_service";
-    const SERVICE_TYPE: ServiceType = ServiceType::OwnProcess;
+    const SERVICE_TYPE: ServiceType = ServiceType::OWN_PROCESS;
 
     const LOOPBACK_ADDR: [u8; 4] = [127, 0, 0, 1];
     const RECEIVER_PORT: u16 = 1234;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@
 //!
 //!     let next_status = ServiceStatus {
 //!         // Should match the one from system service registry
-//!         service_type: ServiceType::OwnProcess,
+//!         service_type: ServiceType::OWN_PROCESS,
 //!         // The new state
 //!         current_state: ServiceState::Running,
 //!         // Accept stop events when running
@@ -225,11 +225,6 @@ error_chain! {
         /// Invalid start argument.
         InvalidStartArgument {
             description("Invalid start argument")
-        }
-        /// Invalid raw representation of [`ServiceType`].
-        InvalidServiceType(raw_value: u32) {
-            description("Invalid service type value")
-            display("Invalid service type value: {}", raw_value)
         }
         /// Invalid raw representation of [`ServiceState`].
         InvalidServiceState(raw_value: u32) {

--- a/src/service_manager.rs
+++ b/src/service_manager.rs
@@ -117,7 +117,7 @@ impl ServiceManager {
     ///     let my_service_info = ServiceInfo {
     ///         name: OsString::from("my_service"),
     ///         display_name: OsString::from("My service"),
-    ///         service_type: ServiceType::OwnProcess,
+    ///         service_type: ServiceType::OWN_PROCESS,
     ///         start_type: ServiceStartType::OnDemand,
     ///         error_control: ServiceErrorControl::Normal,
     ///         executable_path: PathBuf::from(r"C:\path\to\my\service.exe"),
@@ -176,7 +176,7 @@ impl ServiceManager {
                 service_name.as_ptr(),
                 display_name.as_ptr(),
                 service_access.bits(),
-                service_info.service_type.to_raw(),
+                service_info.service_type.bits(),
                 service_info.start_type.to_raw(),
                 service_info.error_control.to_raw(),
                 launch_command.as_ptr(),


### PR DESCRIPTION
Interactive services on Windows have to pass the additional flag `SERVICE_INTERACTIVE_PROCESS` along with the service type itself during registration. That is said, the service type is a bit mask, so we shall define it as such in Rust too. Apart from that this PR adds all other missing service types.

Reference:
https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/nf-winsvc-createservicea

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/17)
<!-- Reviewable:end -->
