### PR TITLE
Adapt code to Rust 2018

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Changed `service_control_handler::register` to accept an `FnMut` rather than just an `Fn` for the
   `event_handler` closure.
+- Upgrade to Rust 2018. This raises the minimum required Rust version to 1.31.0.
 
 ### Fixed
 - Fix invalid pointer manipulations in service creation routine in ServiceManager.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["windows", "service", "daemon"]
 categories = ["api-bindings"]
 repository = "https://github.com/mullvad/windows-service-rs"
 license = "MIT/Apache-2.0"
+edition = "2018"
 
 [target.'cfg(windows)'.dependencies]
 bitflags = "1.0.1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ environment:
       RUST_VERSION: nightly
     # Testing on oldest supported version of Rust
     - TARGET: x86_64-pc-windows-msvc
-      RUST_VERSION: 1.26.0
+      RUST_VERSION: 1.31.0
 
 install:
   - ps: >-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,11 +176,9 @@
 #![recursion_limit = "128"]
 
 #[macro_use]
-extern crate bitflags;
-#[macro_use]
 extern crate error_chain;
-extern crate widestring;
-extern crate winapi;
+
+
 
 pub use error_chain::ChainedError;
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -10,12 +10,12 @@ use winapi::shared::minwindef::DWORD;
 use winapi::shared::winerror::{ERROR_SERVICE_SPECIFIC_ERROR, NO_ERROR};
 use winapi::um::{winnt, winsvc};
 
-use double_nul_terminated;
-use sc_handle::ScHandle;
-use {ErrorKind, Result, ResultExt};
+use crate::double_nul_terminated;
+use crate::sc_handle::ScHandle;
+use crate::{ErrorKind, Result, ResultExt};
 
 /// Enum describing the types of Windows services.
-bitflags! {
+bitflags::bitflags! {
     pub struct ServiceType: DWORD {
         /// File system driver service.
         const FILE_SYSTEM_DRIVER = winnt::SERVICE_FILE_SYSTEM_DRIVER;
@@ -40,7 +40,7 @@ bitflags! {
     }
 }
 
-bitflags! {
+bitflags::bitflags! {
     /// Flags describing the access permissions when working with services
     pub struct ServiceAccess: u32 {
         /// Can query the service status
@@ -398,7 +398,7 @@ impl<'a> From<&'a winsvc::SERVICE_STATUS> for ServiceExitCode {
     }
 }
 
-bitflags! {
+bitflags::bitflags! {
     /// Flags describing accepted types of service control events.
     pub struct ServiceControlAccept: u32 {
         /// The service is a network component that can accept changes in its binding without being

--- a/src/service_control_handler.rs
+++ b/src/service_control_handler.rs
@@ -5,8 +5,8 @@ use widestring::WideCString;
 use winapi::shared::winerror::{ERROR_CALL_NOT_IMPLEMENTED, NO_ERROR};
 use winapi::um::winsvc;
 
-use service::{ServiceControl, ServiceStatus};
-use {ErrorKind, Result, ResultExt};
+use crate::service::{ServiceControl, ServiceStatus};
+use crate::{ErrorKind, Result, ResultExt};
 
 /// A struct that holds a unique token for updating the status of the corresponding service.
 #[derive(Debug, Clone, Copy)]

--- a/src/service_dispatcher.rs
+++ b/src/service_dispatcher.rs
@@ -4,7 +4,7 @@ use std::{io, ptr};
 use widestring::{WideCStr, WideCString};
 use winapi::um::winsvc;
 
-use {ErrorKind, Result, ResultExt};
+use crate::{ErrorKind, Result, ResultExt};
 
 /// A macro to generate an entry point function (aka "service_main") for Windows service.
 ///

--- a/src/service_manager.rs
+++ b/src/service_manager.rs
@@ -5,14 +5,14 @@ use std::{io, ptr};
 use widestring::{NulError, WideCString, WideString};
 use winapi::um::winsvc;
 
-use double_nul_terminated;
-use sc_handle::ScHandle;
-use service::{Service, ServiceAccess, ServiceInfo};
-use shell_escape;
+use crate::double_nul_terminated;
+use crate::sc_handle::ScHandle;
+use crate::service::{Service, ServiceAccess, ServiceInfo};
+use crate::shell_escape;
 
-use {ErrorKind, Result, ResultExt};
+use crate::{ErrorKind, Result, ResultExt};
 
-bitflags! {
+bitflags::bitflags! {
     /// Flags describing access permissions for [`ServiceManager`].
     pub struct ServiceManagerAccess: u32 {
         /// Can connect to service control manager.

--- a/src/shell_escape.rs
+++ b/src/shell_escape.rs
@@ -17,7 +17,7 @@ mod utf16 {
 ///
 /// Inspired by https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/.
 /// Heavily based on https://github.com/sfackler/shell-escape
-pub fn escape(s: Cow<OsStr>) -> Cow<OsStr> {
+pub fn escape(s: Cow<'_, OsStr>) -> Cow<'_, OsStr> {
     static ESCAPE_CHARS: &'static [u16] = &[
         utf16::DOUBLEQUOTE,
         utf16::SPACE,


### PR DESCRIPTION
Slowly looking at upgrading our crates to Rust 2018. To be able to use non-lexical lifetimes, getting rid of `extern crate` and all the other benefits.

This of course also increases the minimum required Rust version to 1.31.0. But virtually everyone is always on latest stable or nightly anyway so I don't think this is a practical problem.