### PR TITLE
feature toggle backtrace in error-chain for legacy os

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,12 @@ edition = "2018"
 
 [target.'cfg(windows)'.dependencies]
 bitflags = "1.0.1"
-error-chain = "0.12"
+error-chain = { version = "0.12", optional = true }
+error-chain-without-backtrace = { version = "0.12", package = "error-chain", default-features = false, optional = true }
 winapi = { version = "0.3.5", features = ["std", "winsvc", "winerror"] }
 widestring = "0.3.0"
+
+[features]
+default = ["with-backtrace"]
+with-backtrace = ["error-chain"]
+legacy-support = ["error-chain-without-backtrace"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,10 +175,13 @@
 // Because of how deeply error-chain recurse with this many error types.
 #![recursion_limit = "128"]
 
+#[cfg(feature = "default")]
 #[macro_use]
 extern crate error_chain;
 
-
+#[cfg(feature = "legacy-support")]
+#[macro_use]
+extern crate error_chain_without_backtrace as error_chain;
 
 pub use error_chain::ChainedError;
 


### PR DESCRIPTION
`error-chain` conditionally uses `backtrace` under the hood which requires a call to `SymFromAddrW`. This is part of `DbgHelp.dll` which is not supported on older operating systems such as XP or Server 2003. Currently, using `windows-service-rs` causes an executable to crash at start because of this missing symbol. This PR introduces a way to feature flag `backtrace` off in `error-chain` without changing anything else in the library. I've tested this against Windows 10 and Server 2003 using the examples and it all seems to be functioning as intended.

`Cargo.toml` usage:
```
windows-service = { version = "*", default-features = false, features = ["legacy-support"] }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/22)
<!-- Reviewable:end -->
