### PR TITLE
easily flip off error-chain backtrace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ edition = "2018"
 
 [target.'cfg(windows)'.dependencies]
 bitflags = "1.0.1"
-error-chain = "0.12"
+error-chain = { version = "0.12", default-features = false }
 winapi = { version = "0.3.5", features = ["std", "winsvc", "winerror"] }
 widestring = "0.3.0"
+
+[features]
+default = ["with-backtrace"]
+with-backtrace = ["error-chain/default"]
+legacy-support = ["error-chain/example_generated"]


### PR DESCRIPTION
see #22 for more discussion. this allows a simple backtrace toggle in error chain. if we'd rather move to [failure](https://github.com/rust-lang-nursery/failure) instead, just close this one and i'll open up another pr with cleaned up changes in my other branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/23)
<!-- Reviewable:end -->
