### PR TITLE
Preserve underlying error

### DIFF
--- a/examples/install_service.rs
+++ b/examples/install_service.rs
@@ -1,13 +1,10 @@
 #[cfg(windows)]
-extern crate windows_service;
-
-#[cfg(windows)]
 fn main() -> windows_service::Result<()> {
     use std::ffi::OsString;
-    use windows_service::service::{
-        ServiceAccess, ServiceErrorControl, ServiceInfo, ServiceStartType, ServiceType,
+    use windows_service::{
+        service::{ServiceAccess, ServiceErrorControl, ServiceInfo, ServiceStartType, ServiceType},
+        service_manager::{ServiceManager, ServiceManagerAccess},
     };
-    use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
 
     let manager_access = ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE;
     let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;

--- a/examples/ping_service.rs
+++ b/examples/ping_service.rs
@@ -11,10 +11,6 @@
 //
 // Ping server sends a text message to local UDP port 1234 once a second.
 // You can verify that service works by running netcat, i.e: `ncat -ul 1234`.
-//
-#[cfg(windows)]
-#[macro_use]
-extern crate windows_service;
 
 #[cfg(windows)]
 fn main() -> windows_service::Result<()> {
@@ -28,26 +24,28 @@ fn main() {
 
 #[cfg(windows)]
 mod ping_service {
-    use std::ffi::OsString;
-    use std::net::{IpAddr, SocketAddr, UdpSocket};
-    use std::sync::mpsc;
-    use std::time::Duration;
-
-    use windows_service::service::{
-        ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState, ServiceStatus,
-        ServiceType,
+    use std::{
+        ffi::OsString,
+        net::{IpAddr, SocketAddr, UdpSocket},
+        sync::mpsc,
+        time::Duration,
     };
-    use windows_service::service_control_handler::{self, ServiceControlHandlerResult};
-    use windows_service::service_dispatcher;
-    use windows_service::Result;
+    use windows_service::{
+        define_windows_service,
+        service::{
+            ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState, ServiceStatus,
+            ServiceType,
+        },
+        service_control_handler::{self, ServiceControlHandlerResult},
+        service_dispatcher, Result,
+    };
 
-
-    const SERVICE_NAME: &'static str = "ping_service";
+    const SERVICE_NAME: &str = "ping_service";
     const SERVICE_TYPE: ServiceType = ServiceType::OWN_PROCESS;
 
     const LOOPBACK_ADDR: [u8; 4] = [127, 0, 0, 1];
     const RECEIVER_PORT: u16 = 1234;
-    const PING_MESSAGE: &'static str = "ping\n";
+    const PING_MESSAGE: &str = "ping\n";
 
     pub fn run() -> Result<()> {
         // Register generated `ffi_service_main` with the system and start the service, blocking

--- a/examples/service_config.rs
+++ b/examples/service_config.rs
@@ -1,11 +1,10 @@
 #[cfg(windows)]
-extern crate windows_service;
-
-#[cfg(windows)]
 fn main() -> windows_service::Result<()> {
     use std::env;
-    use windows_service::service::ServiceAccess;
-    use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+    use windows_service::{
+        service::ServiceAccess,
+        service_manager::{ServiceManager, ServiceManagerAccess},
+    };
 
     let service_name = env::args().nth(1).unwrap_or("netlogon".to_owned());
 

--- a/examples/uninstall_service.rs
+++ b/examples/uninstall_service.rs
@@ -1,12 +1,10 @@
 #[cfg(windows)]
-extern crate windows_service;
-
-#[cfg(windows)]
 fn main() -> windows_service::Result<()> {
-    use std::thread;
-    use std::time::Duration;
-    use windows_service::service::{ServiceAccess, ServiceState};
-    use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+    use std::{thread, time::Duration};
+    use windows_service::{
+        service::{ServiceAccess, ServiceState},
+        service_manager::{ServiceManager, ServiceManagerAccess},
+    };
 
     let manager_access = ServiceManagerAccess::CONNECT;
     let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,10 +234,6 @@ pub enum Error {
     #[error(display = "Invalid service error control type: {}", _0)]
     InvalidServiceErrorControl(u32),
 
-    /// A generic IO error
-    #[error(display = "An IO error has been encountered")]
-    IoError(#[error(cause)] std::io::Error),
-
     /// Failed to send command to service Service deletion to start
     #[error(display = "Could not send commands to service")]
     ServiceControlFailed(#[error(cause)] std::io::Error),
@@ -273,12 +269,6 @@ pub enum Error {
     /// Failed to set service status
     #[error(display = "Could not set service status")]
     ServiceStatusFailed(#[error(cause)] std::io::Error),
-}
-
-impl From<std::io::Error> for Error {
-    fn from(error: std::io::Error) -> Self {
-        Error::IoError(error)
-    }
 }
 
 mod sc_handle;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,39 +180,39 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     /// Invalid account name.
     #[error(display = "Invalid account name")]
-    InvalidAccountName,
+    InvalidAccountName(#[error(cause)] widestring::NulError),
 
     /// Invalid account password.
     #[error(display = "Invalid account password")]
-    InvalidAccountPassword,
+    InvalidAccountPassword(#[error(cause)] widestring::NulError),
 
     /// Invalid display name.
     #[error(display = "Invalid display name")]
-    InvalidDisplayName,
+    InvalidDisplayName(#[error(cause)] widestring::NulError),
 
     /// Invalid database name.
     #[error(display = "Invalid database name")]
-    InvalidDatabaseName,
+    InvalidDatabaseName(#[error(cause)] widestring::NulError),
 
     /// Invalid executable path.
     #[error(display = "Invalid executable path")]
-    InvalidExecutablePath,
+    InvalidExecutablePath(#[error(cause)] widestring::NulError),
 
     /// Invalid launch arguments.
     #[error(display = "Invalid launch argument")]
-    InvalidLaunchArgument,
+    InvalidLaunchArgument(#[error(cause)] widestring::NulError),
 
     /// Invalid dependency name.
     #[error(display = "Invalid dependency name")]
-    InvalidDependency,
+    InvalidDependency(#[error(cause)] widestring::NulError),
 
     /// Invalid machine name.
     #[error(display = "Invalid machine name")]
-    InvalidMachineName,
+    InvalidMachineName(#[error(cause)] widestring::NulError),
 
     /// Invalid service name.
     #[error(display = "Invalid service name")]
-    InvalidServiceName,
+    InvalidServiceName(#[error(cause)] widestring::NulError),
 
     /// Invalid start argument.
     #[error(display = "Invalid start argument")]

--- a/src/service.rs
+++ b/src/service.rs
@@ -524,7 +524,7 @@ impl Service {
     pub fn start<S: AsRef<OsStr>>(&self, service_arguments: &[S]) -> Result<()> {
         let wide_service_arguments = service_arguments
             .iter()
-            .map(|s| WideCString::from_str(s).map_err(|e| Error::InvalidStartArgument(e)))
+            .map(|s| WideCString::from_str(s).map_err(Error::InvalidStartArgument))
             .collect::<Result<Vec<WideCString>>>()?;
 
         let mut raw_service_arguments: Vec<*const u16> =

--- a/src/service.rs
+++ b/src/service.rs
@@ -564,10 +564,10 @@ impl Service {
     }
 
     /// Delete the service from system registry.
-    pub fn delete(self) -> io::Result<()> {
+    pub fn delete(self) -> Result<()> {
         let success = unsafe { winsvc::DeleteService(self.service_handle.raw_handle()) };
         if success == 0 {
-            Err(io::Error::last_os_error())
+            Err(Error::ServiceDeleteFailed(io::Error::last_os_error()))
         } else {
             Ok(())
         }

--- a/src/service_control_handler.rs
+++ b/src/service_control_handler.rs
@@ -103,8 +103,7 @@ where
     // Important: leak the Box<F> which will be released in `service_control_handler`.
     let context: *mut F = Box::into_raw(heap_event_handler);
 
-    let service_name =
-        WideCString::from_str(service_name).map_err(|_| Error::InvalidServiceName)?;
+    let service_name = WideCString::from_str(service_name).map_err(Error::InvalidServiceName)?;
     let status_handle = unsafe {
         winsvc::RegisterServiceCtrlHandlerExW(
             service_name.as_ptr(),

--- a/src/service_dispatcher.rs
+++ b/src/service_dispatcher.rs
@@ -91,8 +91,7 @@ pub fn start<T: AsRef<OsStr>>(
     service_name: T,
     service_main: extern "system" fn(u32, *mut *mut u16),
 ) -> Result<()> {
-    let service_name =
-        WideCString::from_str(service_name).map_err(|_| Error::InvalidServiceName)?;
+    let service_name = WideCString::from_str(service_name).map_err(Error::InvalidServiceName)?;
     let service_table: &[winsvc::SERVICE_TABLE_ENTRYW] = &[
         winsvc::SERVICE_TABLE_ENTRYW {
             lpServiceName: service_name.as_ptr(),

--- a/src/service_manager.rs
+++ b/src/service_manager.rs
@@ -44,8 +44,8 @@ impl ServiceManager {
         database: Option<D>,
         request_access: ServiceManagerAccess,
     ) -> Result<Self> {
-        let machine_name = to_wide(machine).map_err(|_| Error::InvalidMachineName)?;
-        let database_name = to_wide(database).map_err(|_| Error::InvalidDatabaseName)?;
+        let machine_name = to_wide(machine).map_err(Error::InvalidMachineName)?;
+        let database_name = to_wide(database).map_err(Error::InvalidDatabaseName)?;
         let handle = unsafe {
             winsvc::OpenSCManagerW(
                 machine_name.map_or(ptr::null(), |s| s.as_ptr()),
@@ -140,23 +140,22 @@ impl ServiceManager {
         service_access: ServiceAccess,
     ) -> Result<Service> {
         let service_name =
-            WideCString::from_str(service_info.name).map_err(|_| Error::InvalidServiceName)?;
-        let display_name = WideCString::from_str(service_info.display_name)
-            .map_err(|_| Error::InvalidDisplayName)?;
-        let account_name =
-            to_wide(service_info.account_name).map_err(|_| Error::InvalidAccountName)?;
+            WideCString::from_str(service_info.name).map_err(Error::InvalidServiceName)?;
+        let display_name =
+            WideCString::from_str(service_info.display_name).map_err(Error::InvalidDisplayName)?;
+        let account_name = to_wide(service_info.account_name).map_err(Error::InvalidAccountName)?;
         let account_password =
-            to_wide(service_info.account_password).map_err(|_| Error::InvalidAccountPassword)?;
+            to_wide(service_info.account_password).map_err(Error::InvalidAccountPassword)?;
 
         // escape executable path and arguments and combine them into single command
         let executable_path =
-            escape_wide(service_info.executable_path).map_err(|_| Error::InvalidExecutablePath)?;
+            escape_wide(service_info.executable_path).map_err(Error::InvalidExecutablePath)?;
 
         let mut launch_command_buffer = WideString::new();
         launch_command_buffer.push(executable_path);
 
         for launch_argument in service_info.launch_arguments.iter() {
-            let wide = escape_wide(launch_argument).map_err(|_| Error::InvalidLaunchArgument)?;
+            let wide = escape_wide(launch_argument).map_err(Error::InvalidLaunchArgument)?;
 
             launch_command_buffer.push_str(" ");
             launch_command_buffer.push(wide);
@@ -170,7 +169,7 @@ impl ServiceManager {
             .map(|dependency| dependency.to_system_identifier())
             .collect();
         let joined_dependencies = double_nul_terminated::from_vec(&dependency_identifiers)
-            .map_err(|_| Error::InvalidDependency)?;
+            .map_err(Error::InvalidDependency)?;
 
         let service_handle = unsafe {
             winsvc::CreateServiceW(
@@ -225,7 +224,7 @@ impl ServiceManager {
         name: T,
         request_access: ServiceAccess,
     ) -> Result<Service> {
-        let service_name = WideCString::from_str(name).map_err(|_| Error::InvalidServiceName)?;
+        let service_name = WideCString::from_str(name).map_err(Error::InvalidServiceName)?;
         let service_handle = unsafe {
             winsvc::OpenServiceW(
                 self.manager_handle.raw_handle(),


### PR DESCRIPTION
There were a number of places where we had `.map_err(|_| Error::InvalidFoo)`. Thus mapping an existing error type into another one, discarding the original. This will only tell the user of the library that the `Foo` was invalid, but not why/how. By making sure all of them retain the underlying `NulError` it becomes possible for a user of the library to query the underlying `source` of the error.

Also did some unrelated cleanup in the examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/25)
<!-- Reviewable:end -->
