### PR TITLE
Break apart leaf errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,41 +226,9 @@ pub enum Error {
     #[error(display = "Invalid service start type: {}", _0)]
     InvalidServiceStartType(service::TryFromIntError),
 
-    /// Failed to send command to service Service deletion to start
-    #[error(display = "Could not send commands to service")]
-    ServiceControlFailed(#[error(cause)] std::io::Error),
-
-    /// Failed to create service
-    #[error(display = "Could not create service")]
-    ServiceCreateFailed(#[error(cause)] std::io::Error),
-
-    /// Service deletion failed
-    #[error(display = "Could not delete service")]
-    ServiceDeleteFailed(#[error(cause)] std::io::Error),
-
-    /// Failed to connect to service manager
-    #[error(display = "Could not connect to service manager")]
-    ServiceManagerConnectFailed(#[error(cause)] std::io::Error),
-
-    /// Failed to open service
-    #[error(display = "Could not open service")]
-    ServiceOpenFailed(#[error(cause)] std::io::Error),
-
-    /// Failed to query Service
-    #[error(display = "Could not query service")]
-    ServiceQueryFailed(#[error(cause)] std::io::Error),
-
-    /// Failed to register service
-    #[error(display = "Could not register service")]
-    ServiceRegisterFailed(#[error(cause)] std::io::Error),
-
-    /// Service failed to start
-    #[error(display = "Could not start service")]
-    ServiceStartFailed(#[error(cause)] std::io::Error),
-
-    /// Failed to set service status
-    #[error(display = "Could not set service status")]
-    ServiceStatusFailed(#[error(cause)] std::io::Error),
+    /// IO error when calling winapi
+    #[error(display = "IO error in winapi call")]
+    Winapi(#[error(cause)] std::io::Error),
 }
 
 mod sc_handle;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,19 +220,11 @@ pub enum Error {
 
     /// Invalid raw representation of [`ServiceState`].
     #[error(display = "Invalid service state value: {}", _0)]
-    InvalidServiceState(u32),
-
-    /// Invalid raw representation of [`ServiceControl`].
-    #[error(display = "Invalid service control value: {}", _0)]
-    InvalidServiceControl(u32),
+    InvalidServiceState(service::TryFromIntError),
 
     /// Invalid raw representation of [`ServiceStartType`].
     #[error(display = "Invalid service start type: {}", _0)]
-    InvalidServiceStartType(u32),
-
-    /// Invalid raw representation of [`ServiceErrorControl`].
-    #[error(display = "Invalid service error control type: {}", _0)]
-    InvalidServiceErrorControl(u32),
+    InvalidServiceStartType(service::TryFromIntError),
 
     /// Failed to send command to service Service deletion to start
     #[error(display = "Could not send commands to service")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,12 +219,16 @@ pub enum Error {
     InvalidStartArgument(#[error(cause)] widestring::NulError),
 
     /// Invalid raw representation of [`ServiceState`].
-    #[error(display = "Invalid service state value: {}", _0)]
-    InvalidServiceState(service::TryFromIntError),
+    #[error(display = "Invalid service state value")]
+    InvalidServiceState(#[error(cause)] service::ParseRawError),
 
     /// Invalid raw representation of [`ServiceStartType`].
-    #[error(display = "Invalid service start type: {}", _0)]
-    InvalidServiceStartType(service::TryFromIntError),
+    #[error(display = "Invalid service start value")]
+    InvalidServiceStartType(#[error(cause)] service::ParseRawError),
+
+    /// Invalid raw representation of [`ServiceErrorControl`].
+    #[error(display = "Invalid service error control value")]
+    InvalidServiceErrorControl(#[error(cause)] service::ParseRawError),
 
     /// IO error when calling winapi
     #[error(display = "IO error in winapi call")]

--- a/src/service_control_handler.rs
+++ b/src/service_control_handler.rs
@@ -18,11 +18,11 @@ impl ServiceStatusHandle {
     }
 
     /// Report the new service status to the system.
-    pub fn set_service_status(&self, service_status: ServiceStatus) -> Result<()> {
+    pub fn set_service_status(&self, service_status: ServiceStatus) -> crate::Result<()> {
         let mut raw_service_status = service_status.to_raw();
         let result = unsafe { winsvc::SetServiceStatus(self.0, &mut raw_service_status) };
         if result == 0 {
-            Err(Error::ServiceStatusFailed(io::Error::last_os_error()))
+            Err(Error::Winapi(io::Error::last_os_error()))
         } else {
             Ok(())
         }
@@ -115,7 +115,7 @@ where
     if status_handle.is_null() {
         // Release the `event_handler` in case of an error.
         let _: Box<F> = unsafe { Box::from_raw(context) };
-        Err(Error::ServiceRegisterFailed(io::Error::last_os_error()))
+        Err(Error::Winapi(io::Error::last_os_error()))
     } else {
         Ok(ServiceStatusHandle::from_handle(status_handle))
     }

--- a/src/service_dispatcher.rs
+++ b/src/service_dispatcher.rs
@@ -106,7 +106,7 @@ pub fn start<T: AsRef<OsStr>>(
 
     let result = unsafe { winsvc::StartServiceCtrlDispatcherW(service_table.as_ptr()) };
     if result == 0 {
-        Err(Error::ServiceStartFailed(io::Error::last_os_error()))
+        Err(Error::Winapi(io::Error::last_os_error()))
     } else {
         Ok(())
     }

--- a/src/service_manager.rs
+++ b/src/service_manager.rs
@@ -55,9 +55,7 @@ impl ServiceManager {
         };
 
         if handle.is_null() {
-            Err(Error::ServiceManagerConnectFailed(
-                io::Error::last_os_error(),
-            ))
+            Err(Error::Winapi(io::Error::last_os_error()))
         } else {
             Ok(ServiceManager {
                 manager_handle: unsafe { ScHandle::new(handle) },
@@ -161,7 +159,8 @@ impl ServiceManager {
             launch_command_buffer.push(wide);
         }
 
-        let launch_command = WideCString::from_wide_str(launch_command_buffer).unwrap();
+        let launch_command = WideCString::from_wide_str(launch_command_buffer)
+            .expect("launch_command_buffer invalidly formatted");
 
         let dependency_identifiers: Vec<OsString> = service_info
             .dependencies
@@ -194,7 +193,7 @@ impl ServiceManager {
         };
 
         if service_handle.is_null() {
-            Err(Error::ServiceCreateFailed(io::Error::last_os_error()))
+            Err(Error::Winapi(io::Error::last_os_error()))
         } else {
             Ok(Service::new(unsafe { ScHandle::new(service_handle) }))
         }
@@ -234,7 +233,7 @@ impl ServiceManager {
         };
 
         if service_handle.is_null() {
-            Err(Error::ServiceOpenFailed(io::Error::last_os_error()))
+            Err(Error::Winapi(io::Error::last_os_error()))
         } else {
             Ok(Service::new(unsafe { ScHandle::new(service_handle) }))
         }


### PR DESCRIPTION
I try again to simplify/clean the error type(s) and make the error handling abstracted on a good and nice level. I'm experimenting a bit, and I'm not 100% sure I have reached the optimal design, but I'm thinking it's starting to be rather nice now.

This PR basically does two things to the errors:

1. Make all `from_raw(u32)` constructors return a unified `TryFromIntError(u32)`. Much like how the standard library implementations of `TryFrom` on integers return one single error type.

    I still need to keep two of the previous `from_raw` error variants on the combination `Error` enum. Since those can happen as part of methods with multiple types of errors in them.

    Overall I think this is cleaner. On the lower level, constructors like `ServiceStatus::from_raw` no longer return a huge error with many variants. Instead it just returns a very tiny and simple error informing that the given integer was not correct.


2. Join all errors containing an `io::Error` into one `Error::Winapi` variant. I'm aware that this goes completely against how I argued in #24 very recently. Sorry for this @rustysec. But I have an explanation. When I argued each IO error should have its own variant I was under the impression that at least one method where IO errors could happen had >1 potential source of IO errors in them. Therefore making it important to separate them, so the caller could figure out which of the multiple winapi calls failed. But upon further inspection I see now that each method does no more than one winapi call. As such, it's enough if the returned error indicate that **the** winapi call failed.

    This also makes the error abstraction level more symmetrical. An example: Now `Service::start` can error with either the `InvalidStartArgument` or the `Winapi` error variant. This is clear, either the caller gave an invalid argument, or the actual start call failed. Simple. Previously it could error with either the `InvalidStartArgument` or the `ServiceStartFailed` error variant. I feel that the `ServiceStartFailed` error should be one level higher. The `InvalidStartArgument` should be a **cause** of the `ServiceStartFailed` error, it should not be its sibling. With this restructure any caller to `Service::start` is now free to wrap the returned error in some `ServiceStartFailed` error, and the cause of failing to start it is either because the arguments were wrong, or the winapi call failed.


Please provide feedback and we'll reach something awesome together :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/26)
<!-- Reviewable:end -->
