### PR TITLE
Add service failure actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- Add support for service failure actions. (See: `ServiceFailureActions`, 
+  `Service::update_failure_actions`, `Service::get_failure_actions`, 
+  `Service::set_failure_actions_on_non_crash_failures`, 
+  `Service::get_failure_actions_on_non_crash_failures`)
 
 ## [0.2.0] - 2019-04-01
 ### Added
-- A `ServiceExitCode::NO_ERROR` constant for easy access to the success value.
+- Add `ServiceExitCode::NO_ERROR` constant for easy access to the success value.
 - Add `Service::start` for starting services programmatically.
 - Add `Service::query_config` for getting the config of the service.
 - Add `ServiceInfo::dependencies` for specifying service dependencies.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2018"
 [target.'cfg(windows)'.dependencies]
 bitflags = "1.0.1"
 err-derive = "0.1.5"
-winapi = { version = "0.3.5", features = ["std", "winsvc", "winerror"] }
+winapi = { git = "https://github.com/mullvad/winapi-rs.git", rev = "4bcf5cab87124bbeef8c1a445137494d874f8082", features = ["std", "winsvc", "winbase", "winerror"] }
 widestring = "0.3.0"

--- a/examples/service_failure_actions.rs
+++ b/examples/service_failure_actions.rs
@@ -1,0 +1,93 @@
+#[cfg(windows)]
+fn main() -> windows_service::Result<()> {
+    use std::ffi::OsString;
+    use std::time::Duration;
+    use windows_service::{
+        service::{
+            ServiceAccess, ServiceAction, ServiceActionType, ServiceErrorControl,
+            ServiceFailureActions, ServiceFailureResetPeriod, ServiceInfo, ServiceStartType,
+            ServiceType,
+        },
+        service_manager::{ServiceManager, ServiceManagerAccess},
+    };
+
+    const SERVICE_NAME: &str = "service_failure_actions_example";
+
+    let manager_access = ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE;
+    let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
+
+    let service_binary_path = ::std::env::current_exe()
+        .unwrap()
+        .with_file_name("service_failure_actions.exe");
+
+    let service_info = ServiceInfo {
+        name: OsString::from(SERVICE_NAME),
+        display_name: OsString::from("Service Failure Actions Example"),
+        service_type: ServiceType::OWN_PROCESS,
+        start_type: ServiceStartType::OnDemand,
+        error_control: ServiceErrorControl::Normal,
+        executable_path: service_binary_path,
+        launch_arguments: vec![],
+        dependencies: vec![],
+        account_name: None, // run as System
+        account_password: None,
+    };
+
+    let service_access = ServiceAccess::QUERY_CONFIG
+        | ServiceAccess::CHANGE_CONFIG
+        | ServiceAccess::START
+        | ServiceAccess::DELETE;
+
+    println!("Create or open the service {}", SERVICE_NAME);
+    let service = service_manager
+        .create_service(service_info, service_access)
+        .or(service_manager.open_service(SERVICE_NAME, service_access))?;
+
+    let actions = vec![
+        ServiceAction {
+            action_type: ServiceActionType::Restart,
+            delay: Duration::from_secs(5),
+        },
+        ServiceAction {
+            action_type: ServiceActionType::RunCommand,
+            delay: Duration::from_secs(10),
+        },
+        ServiceAction {
+            action_type: ServiceActionType::None,
+            delay: Duration::default(),
+        },
+    ];
+
+    println!("Update failure actions");
+    let failure_actions = ServiceFailureActions {
+        reset_period: ServiceFailureResetPeriod::After(Duration::from_secs(86400 * 2)),
+        reboot_msg: None,
+        command: Some(OsString::from("ping 127.0.0.1")),
+        actions: Some(actions),
+    };
+    service.update_failure_actions(failure_actions)?;
+
+    println!("Query failure actions");
+    let updated_failure_actions = service.get_failure_actions()?;
+    println!("{:#?}", updated_failure_actions);
+
+    println!("Enable failure actions on non-crash failures");
+    service.set_failure_actions_on_non_crash_failures(true)?;
+
+    println!("Query failure actions on non-crash failures enabled");
+    let failure_actions_flag = service.get_failure_actions_on_non_crash_failures()?;
+    println!(
+        "Failure actions on non-crash failures enabled: {}",
+        failure_actions_flag
+    );
+
+    println!("Delete the service {}", SERVICE_NAME);
+    service.delete()?;
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn main() {
+    panic!("This program is only intended to run on Windows.");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,9 @@
 //! [`ServiceStatus::checkpoint`]: service::ServiceStatus::checkpoint
 //! [`StartPending`]: service::ServiceState::StartPending
 //! [`Running`]: service::ServiceState::Running
+//! [`ServiceActionType`]: service::ServiceActionType
+//! [`ServiceErrorControl`]: service::ServiceErrorControl
+//! [`ServiceState`]: service::ServiceState
 
 #![cfg(windows)]
 
@@ -229,6 +232,18 @@ pub enum Error {
     /// Invalid raw representation of [`ServiceErrorControl`].
     #[error(display = "Invalid service error control value")]
     InvalidServiceErrorControl(#[error(cause)] service::ParseRawError),
+
+    /// Invalid raw representation of [`ServiceActionType`]
+    #[error(display = "Invalid service action type")]
+    InvalidServiceActionType(#[error(cause)] service::ParseRawError),
+
+    /// Invalid reboot message
+    #[error(display = "Invalid service action failures reboot message")]
+    InvalidServiceActionFailuresRebootMessage(#[error(cause)] widestring::NulError),
+
+    /// Invalid command
+    #[error(display = "Invalid service action failures command")]
+    InvalidServiceActionFailuresCommand(#[error(cause)] widestring::NulError),
 
     /// IO error when calling winapi
     #[error(display = "IO error in winapi call")]


### PR DESCRIPTION
This PR adds service failure actions configuration in the `Service` struct.

- `Service.get_failure_actions() -> Result<ServiceFailureActions>` returns the currently configured failure actions `ServiceFailureActions` struct.
- `Service.update_failure_actions(ServiceFailureActions)`  does incremental update to the failure actions config. Basically almost all of the fields in `ServiceFailureActions` are optional, so passing `None` would leave the corresponding setting unchanged, however passing an empty value would reset it, i.e for strings `Some("")` or for vectors `Some(vec![])`.
- `Service.set_failure_actions_on_non_crash_failures(bool)` - enables failure actions for non-crash failures, i.e if the service exited with non-zero code (not the same as process exit code, but the one passed via `ServiceStatus` struct _or_ if the service was terminated before sending the "stopped" status update.

- `Service.get_failure_actions_on_non_crash_failures() -> Result<bool>` - a getter method for the method above.

Please have a look at `examples/service_failure_actions.rs`.

ps: waiting for https://github.com/retep998/winapi-rs/pull/790 to be merged with the missing ffi.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/29)
<!-- Reviewable:end -->
