### PR TITLE
Upgrade dependencies. And adapt to new widestrings API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [target.'cfg(windows)'.dependencies]
-bitflags = "1.0.1"
+bitflags = "1.2"
 err-derive = "0.1.5"
 winapi = { git = "https://github.com/mullvad/winapi-rs.git", rev = "4bcf5cab87124bbeef8c1a445137494d874f8082", features = ["dbt", "std", "winbase", "winerror", "winsvc"] }
-widestring = "0.3.0"
+widestring = "0.4.0"

--- a/examples/ping_service.rs
+++ b/examples/ping_service.rs
@@ -135,5 +135,4 @@ mod ping_service {
 
         Ok(())
     }
-
 }

--- a/src/double_nul_terminated.rs
+++ b/src/double_nul_terminated.rs
@@ -12,13 +12,13 @@ use winapi::shared::ntdef::LPWSTR;
 /// "item one\0item two\0\0"
 ///
 /// Returns None if the source collection is empty.
-pub fn from_vec<T: AsRef<OsStr>>(source: &[T]) -> Result<Option<WideString>, NulError> {
+pub fn from_vec(source: &[impl AsRef<OsStr>]) -> Result<Option<WideString>, NulError<u16>> {
     if source.is_empty() {
         Ok(None)
     } else {
         let mut wide = WideString::new();
         for s in source {
-            let checked_str = WideCString::from_str(s)?;
+            let checked_str = WideCString::from_os_str(s)?;
             wide.push_slice(checked_str);
             wide.push_slice(&[0]);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,43 +183,43 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     /// Invalid account name.
     #[error(display = "Invalid account name")]
-    InvalidAccountName(#[error(cause)] widestring::NulError),
+    InvalidAccountName(#[error(cause)] widestring::NulError<u16>),
 
     /// Invalid account password.
     #[error(display = "Invalid account password")]
-    InvalidAccountPassword(#[error(cause)] widestring::NulError),
+    InvalidAccountPassword(#[error(cause)] widestring::NulError<u16>),
 
     /// Invalid display name.
     #[error(display = "Invalid display name")]
-    InvalidDisplayName(#[error(cause)] widestring::NulError),
+    InvalidDisplayName(#[error(cause)] widestring::NulError<u16>),
 
     /// Invalid database name.
     #[error(display = "Invalid database name")]
-    InvalidDatabaseName(#[error(cause)] widestring::NulError),
+    InvalidDatabaseName(#[error(cause)] widestring::NulError<u16>),
 
     /// Invalid executable path.
     #[error(display = "Invalid executable path")]
-    InvalidExecutablePath(#[error(cause)] widestring::NulError),
+    InvalidExecutablePath(#[error(cause)] widestring::NulError<u16>),
 
     /// Invalid launch arguments.
     #[error(display = "Invalid launch argument")]
-    InvalidLaunchArgument(#[error(cause)] widestring::NulError),
+    InvalidLaunchArgument(#[error(cause)] widestring::NulError<u16>),
 
     /// Invalid dependency name.
     #[error(display = "Invalid dependency name")]
-    InvalidDependency(#[error(cause)] widestring::NulError),
+    InvalidDependency(#[error(cause)] widestring::NulError<u16>),
 
     /// Invalid machine name.
     #[error(display = "Invalid machine name")]
-    InvalidMachineName(#[error(cause)] widestring::NulError),
+    InvalidMachineName(#[error(cause)] widestring::NulError<u16>),
 
     /// Invalid service name.
     #[error(display = "Invalid service name")]
-    InvalidServiceName(#[error(cause)] widestring::NulError),
+    InvalidServiceName(#[error(cause)] widestring::NulError<u16>),
 
     /// Invalid start argument.
     #[error(display = "Invalid start argument")]
-    InvalidStartArgument(#[error(cause)] widestring::NulError),
+    InvalidStartArgument(#[error(cause)] widestring::NulError<u16>),
 
     /// Invalid raw representation of [`ServiceState`].
     #[error(display = "Invalid service state value")]
@@ -239,11 +239,11 @@ pub enum Error {
 
     /// Invalid reboot message
     #[error(display = "Invalid service action failures reboot message")]
-    InvalidServiceActionFailuresRebootMessage(#[error(cause)] widestring::NulError),
+    InvalidServiceActionFailuresRebootMessage(#[error(cause)] widestring::NulError<u16>),
 
     /// Invalid command
     #[error(display = "Invalid service action failures command")]
-    InvalidServiceActionFailuresCommand(#[error(cause)] widestring::NulError),
+    InvalidServiceActionFailuresCommand(#[error(cause)] widestring::NulError<u16>),
 
     /// IO error when calling winapi
     #[error(display = "IO error in winapi call")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,8 +202,8 @@ pub enum Error {
     InvalidExecutablePath(#[error(cause)] widestring::NulError<u16>),
 
     /// Invalid launch arguments.
-    #[error(display = "Invalid launch argument")]
-    InvalidLaunchArgument(#[error(cause)] widestring::NulError<u16>),
+    #[error(display = "Invalid launch argument at index {}", _0)]
+    InvalidLaunchArgument(usize, #[error(cause)] widestring::NulError<u16>),
 
     /// Invalid dependency name.
     #[error(display = "Invalid dependency name")]

--- a/src/service.rs
+++ b/src/service.rs
@@ -1415,7 +1415,11 @@ impl Service {
     }
 
     /// Private helper to query the optional configuration parameters of windows services.
-    unsafe fn query_config2<T: Copy>(&self, kind: DWORD, data: &mut [u8; MAX_QUERY_BUFFER_SIZE]) -> io::Result<T> {
+    unsafe fn query_config2<T: Copy>(
+        &self,
+        kind: DWORD,
+        data: &mut [u8; MAX_QUERY_BUFFER_SIZE],
+    ) -> io::Result<T> {
         let mut bytes_written: u32 = 0;
 
         let success = winsvc::QueryServiceConfig2W(

--- a/src/service.rs
+++ b/src/service.rs
@@ -1185,10 +1185,10 @@ impl Service {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn start<S: AsRef<OsStr>>(&self, service_arguments: &[S]) -> crate::Result<()> {
+    pub fn start(&self, service_arguments: &[impl AsRef<OsStr>]) -> crate::Result<()> {
         let wide_service_arguments = service_arguments
             .iter()
-            .map(|s| WideCString::from_str(s).map_err(Error::InvalidStartArgument))
+            .map(|s| WideCString::from_os_str(s).map_err(Error::InvalidStartArgument))
             .collect::<crate::Result<Vec<WideCString>>>()?;
 
         let mut raw_service_arguments: Vec<*const u16> =
@@ -1452,12 +1452,12 @@ impl Service {
 /// The maximum size of data buffer used by QueryServiceConfigW and QueryServiceConfig2W is 8K
 const MAX_QUERY_BUFFER_SIZE: usize = 8 * 1024;
 
-fn to_wide_slice<T: AsRef<OsStr>>(
-    s: Option<T>,
-) -> ::std::result::Result<Option<Vec<u16>>, NulError> {
+fn to_wide_slice(
+    s: Option<impl AsRef<OsStr>>,
+) -> ::std::result::Result<Option<Vec<u16>>, NulError<u16>> {
     if let Some(s) = s {
         Ok(Some(
-            WideCString::from_str(s).map(|s| s.as_slice_with_nul().to_vec())?,
+            WideCString::from_os_str(s).map(|s| s.as_slice_with_nul().to_vec())?,
         ))
     } else {
         Ok(None)

--- a/src/service_control_handler.rs
+++ b/src/service_control_handler.rs
@@ -92,9 +92,8 @@ impl ServiceControlHandlerResult {
 ///
 /// # fn main() {}
 /// ```
-pub fn register<S, F>(service_name: S, event_handler: F) -> Result<ServiceStatusHandle>
+pub fn register<F>(service_name: impl AsRef<OsStr>, event_handler: F) -> Result<ServiceStatusHandle>
 where
-    S: AsRef<OsStr>,
     F: FnMut(ServiceControl) -> ServiceControlHandlerResult + 'static + Send,
 {
     // Move closure to heap.
@@ -103,7 +102,7 @@ where
     // Important: leak the Box<F> which will be released in `service_control_handler`.
     let context: *mut F = Box::into_raw(heap_event_handler);
 
-    let service_name = WideCString::from_str(service_name).map_err(Error::InvalidServiceName)?;
+    let service_name = WideCString::from_os_str(service_name).map_err(Error::InvalidServiceName)?;
     let status_handle = unsafe {
         winsvc::RegisterServiceCtrlHandlerExW(
             service_name.as_ptr(),

--- a/src/service_dispatcher.rs
+++ b/src/service_dispatcher.rs
@@ -87,11 +87,11 @@ macro_rules! define_windows_service {
 ///     Ok(())
 /// }
 /// ```
-pub fn start<T: AsRef<OsStr>>(
-    service_name: T,
+pub fn start(
+    service_name: impl AsRef<OsStr>,
     service_main: extern "system" fn(u32, *mut *mut u16),
 ) -> Result<()> {
-    let service_name = WideCString::from_str(service_name).map_err(Error::InvalidServiceName)?;
+    let service_name = WideCString::from_os_str(service_name).map_err(Error::InvalidServiceName)?;
     let service_table: &[winsvc::SERVICE_TABLE_ENTRYW] = &[
         winsvc::SERVICE_TABLE_ENTRYW {
             lpServiceName: service_name.as_ptr(),

--- a/src/service_manager.rs
+++ b/src/service_manager.rs
@@ -152,8 +152,9 @@ impl ServiceManager {
         let mut launch_command_buffer = WideString::new();
         launch_command_buffer.push(executable_path);
 
-        for launch_argument in service_info.launch_arguments.iter() {
-            let wide = escape_wide(launch_argument).map_err(Error::InvalidLaunchArgument)?;
+        for (i, launch_argument) in service_info.launch_arguments.iter().enumerate() {
+            let wide =
+                escape_wide(launch_argument).map_err(|e| Error::InvalidLaunchArgument(i, e))?;
 
             launch_command_buffer.push_str(" ");
             launch_command_buffer.push(wide);

--- a/src/service_manager.rs
+++ b/src/service_manager.rs
@@ -161,8 +161,7 @@ impl ServiceManager {
         }
 
         // Safety: We are sure launch_command_buffer does not contain nulls
-        let launch_command =
-            unsafe { WideCString::from_vec_unchecked(launch_command_buffer.into_vec()) };
+        let launch_command = unsafe { WideCString::from_ustr_unchecked(launch_command_buffer) };
 
         let dependency_identifiers: Vec<OsString> = service_info
             .dependencies

--- a/src/service_manager.rs
+++ b/src/service_manager.rs
@@ -254,6 +254,6 @@ fn to_wide(
 /// Escapes a given string, but also checks it does not contain any null bytes
 fn escape_wide(s: impl AsRef<OsStr>) -> ::std::result::Result<WideString, NulError<u16>> {
     let escaped = shell_escape::escape(Cow::Borrowed(s.as_ref()));
-    let _ = WideCString::from_os_str(&escaped)?;
-    Ok(WideString::from_os_str(&escaped))
+    let wide = WideCString::from_os_str(&escaped)?;
+    Ok(wide.to_ustring())
 }


### PR DESCRIPTION
I found there were two breaking upgrades to our dependencies. `bitflags` was painless, but `widestrings` had changed their API a bit. Mostly that the error type is now generic over the backing integer type, and that `from_str` is now named `from_os_str` if converting from an `&OsStr`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/34)
<!-- Reviewable:end -->
