### PR TITLE
Point docs.rs to the Windows docs by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/mullvad/windows-service-rs"
 license = "MIT/Apache-2.0"
 edition = "2018"
 
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"
+
 [target.'cfg(windows)'.dependencies]
 bitflags = "1.2"
 err-derive = "0.1.5"


### PR DESCRIPTION
As suggested by @retep998. Making it so that going to this crate on docs.rs will go directly to the Windows version. Which is the only version that makes sense really.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/35)
<!-- Reviewable:end -->
