### PR TITLE
Upgrade err derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `Service::set_failure_actions_on_non_crash_failures`, 
   `Service::get_failure_actions_on_non_crash_failures`)
 
+### Changed
+- Bumped the MSRV to 1.32, because of err-derive which depend on quote
+
 ## [0.2.0] - 2019-04-01
 ### Added
 - Add `ServiceExitCode::NO_ERROR` constant for easy access to the success value.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ default-target = "x86_64-pc-windows-msvc"
 
 [target.'cfg(windows)'.dependencies]
 bitflags = "1.2"
-err-derive = "0.1.5"
+err-derive = "0.2.1"
 winapi = { git = "https://github.com/mullvad/winapi-rs.git", rev = "4bcf5cab87124bbeef8c1a445137494d874f8082", features = ["dbt", "std", "winbase", "winerror", "winsvc"] }
 widestring = "0.4.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ environment:
       RUST_VERSION: nightly
     # Testing on oldest supported version of Rust
     - TARGET: x86_64-pc-windows-msvc
-      RUST_VERSION: 1.31.0
+      RUST_VERSION: 1.32.0
 
 install:
   - ps: >-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,74 +180,75 @@
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(err_derive::Error, Debug)]
+#[error(no_from)]
 pub enum Error {
     /// Invalid account name.
     #[error(display = "Invalid account name")]
-    InvalidAccountName(#[error(cause)] widestring::NulError<u16>),
+    InvalidAccountName(#[error(source)] widestring::NulError<u16>),
 
     /// Invalid account password.
     #[error(display = "Invalid account password")]
-    InvalidAccountPassword(#[error(cause)] widestring::NulError<u16>),
+    InvalidAccountPassword(#[error(source)] widestring::NulError<u16>),
 
     /// Invalid display name.
     #[error(display = "Invalid display name")]
-    InvalidDisplayName(#[error(cause)] widestring::NulError<u16>),
+    InvalidDisplayName(#[error(source)] widestring::NulError<u16>),
 
     /// Invalid database name.
     #[error(display = "Invalid database name")]
-    InvalidDatabaseName(#[error(cause)] widestring::NulError<u16>),
+    InvalidDatabaseName(#[error(source)] widestring::NulError<u16>),
 
     /// Invalid executable path.
     #[error(display = "Invalid executable path")]
-    InvalidExecutablePath(#[error(cause)] widestring::NulError<u16>),
+    InvalidExecutablePath(#[error(source)] widestring::NulError<u16>),
 
     /// Invalid launch arguments.
     #[error(display = "Invalid launch argument at index {}", _0)]
-    InvalidLaunchArgument(usize, #[error(cause)] widestring::NulError<u16>),
+    InvalidLaunchArgument(usize, #[error(source)] widestring::NulError<u16>),
 
     /// Invalid dependency name.
     #[error(display = "Invalid dependency name")]
-    InvalidDependency(#[error(cause)] widestring::NulError<u16>),
+    InvalidDependency(#[error(source)] widestring::NulError<u16>),
 
     /// Invalid machine name.
     #[error(display = "Invalid machine name")]
-    InvalidMachineName(#[error(cause)] widestring::NulError<u16>),
+    InvalidMachineName(#[error(source)] widestring::NulError<u16>),
 
     /// Invalid service name.
     #[error(display = "Invalid service name")]
-    InvalidServiceName(#[error(cause)] widestring::NulError<u16>),
+    InvalidServiceName(#[error(source)] widestring::NulError<u16>),
 
     /// Invalid start argument.
     #[error(display = "Invalid start argument")]
-    InvalidStartArgument(#[error(cause)] widestring::NulError<u16>),
+    InvalidStartArgument(#[error(source)] widestring::NulError<u16>),
 
     /// Invalid raw representation of [`ServiceState`].
     #[error(display = "Invalid service state value")]
-    InvalidServiceState(#[error(cause)] service::ParseRawError),
+    InvalidServiceState(#[error(source)] service::ParseRawError),
 
     /// Invalid raw representation of [`ServiceStartType`].
     #[error(display = "Invalid service start value")]
-    InvalidServiceStartType(#[error(cause)] service::ParseRawError),
+    InvalidServiceStartType(#[error(source)] service::ParseRawError),
 
     /// Invalid raw representation of [`ServiceErrorControl`].
     #[error(display = "Invalid service error control value")]
-    InvalidServiceErrorControl(#[error(cause)] service::ParseRawError),
+    InvalidServiceErrorControl(#[error(source)] service::ParseRawError),
 
     /// Invalid raw representation of [`ServiceActionType`]
     #[error(display = "Invalid service action type")]
-    InvalidServiceActionType(#[error(cause)] service::ParseRawError),
+    InvalidServiceActionType(#[error(source)] service::ParseRawError),
 
     /// Invalid reboot message
     #[error(display = "Invalid service action failures reboot message")]
-    InvalidServiceActionFailuresRebootMessage(#[error(cause)] widestring::NulError<u16>),
+    InvalidServiceActionFailuresRebootMessage(#[error(source)] widestring::NulError<u16>),
 
     /// Invalid command
     #[error(display = "Invalid service action failures command")]
-    InvalidServiceActionFailuresCommand(#[error(cause)] widestring::NulError<u16>),
+    InvalidServiceActionFailuresCommand(#[error(source)] widestring::NulError<u16>),
 
     /// IO error when calling winapi
     #[error(display = "IO error in winapi call")]
-    Winapi(#[error(cause)] std::io::Error),
+    Winapi(#[error(source)] std::io::Error),
 }
 
 mod sc_handle;


### PR DESCRIPTION
Upgrade the `err-derive` dependency. Not because we need really, but we had to bump the MSRV anyway, since `err-derive 0.1.6` bumped the `quote` depndency to 1.0 which increased MSRV. Some people don't regard requiring newer Rust as a breaking change. Anyway, when I was at it I upgraded to their breaking change 0.2 as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/36)
<!-- Reviewable:end -->
