### PR TITLE
Treat 'ServiceAction' delay field as count of milliseconds

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -207,14 +207,14 @@ impl ServiceAction {
         Ok(ServiceAction {
             action_type: ServiceActionType::from_raw(raw.Type)
                 .map_err(Error::InvalidServiceActionType)?,
-            delay: Duration::from_secs(raw.Delay as u64),
+            delay: Duration::from_millis(raw.Delay as u64),
         })
     }
 
     pub fn to_raw(&self) -> winsvc::SC_ACTION {
         winsvc::SC_ACTION {
             Type: self.action_type.to_raw(),
-            Delay: self.delay.as_secs() as DWORD,
+            Delay: (self.delay.as_secs() * 1000) as DWORD,
         }
     }
 }


### PR DESCRIPTION
As above.

The output from `service_failure_actions.rs` seems to be unchanged. Which makes sense, because there was always a symmetry in how we handled this value.

I've verified the changes by looking at how the services applet in Windows interprets the delay value. With these changes, both our code and the services applet have a mutual understanding of how the value should be interpreted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/37)
<!-- Reviewable:end -->
