### PR TITLE
Use precise delay duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `Service::get_failure_actions_on_non_crash_failures`)
 
 ### Changed
-- Bumped the MSRV to 1.33, because of err-derive upgrade which depend on quote, and to use
-  `Duration::as_millis()`.
+- Bumped the MSRV to 1.34, because of err-derive upgrade which depend on quote, to use
+  `Duration::as_millis()` and the `TryFrom` trait.
 
 ## [0.2.0] - 2019-04-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `Service::get_failure_actions_on_non_crash_failures`)
 
 ### Changed
-- Bumped the MSRV to 1.32, because of err-derive which depend on quote
+- Bumped the MSRV to 1.33, because of err-derive upgrade which depend on quote, and to use
+  `Duration::as_millis()`.
 
 ## [0.2.0] - 2019-04-01
 ### Added

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ environment:
       RUST_VERSION: nightly
     # Testing on oldest supported version of Rust
     - TARGET: x86_64-pc-windows-msvc
-      RUST_VERSION: 1.33.0
+      RUST_VERSION: 1.34.0
 
 install:
   - ps: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ environment:
       RUST_VERSION: nightly
     # Testing on oldest supported version of Rust
     - TARGET: x86_64-pc-windows-msvc
-      RUST_VERSION: 1.32.0
+      RUST_VERSION: 1.33.0
 
 install:
   - ps: >-

--- a/src/service.rs
+++ b/src/service.rs
@@ -214,7 +214,7 @@ impl ServiceAction {
     pub fn to_raw(&self) -> winsvc::SC_ACTION {
         winsvc::SC_ACTION {
             Type: self.action_type.to_raw(),
-            Delay: (self.delay.as_secs() * 1000) as DWORD,
+            Delay: self.delay.as_millis() as DWORD,
         }
     }
 }
@@ -1132,8 +1132,7 @@ impl ServiceStatus {
 
         raw_status.dwCheckPoint = self.checkpoint;
 
-        // we lose precision here but dwWaitHint should never be too big.
-        raw_status.dwWaitHint = (self.wait_hint.as_secs() * 1000) as u32;
+        raw_status.dwWaitHint = self.wait_hint.as_millis() as u32;
 
         raw_status
     }


### PR DESCRIPTION
Make use of `Duration::as_millis()` instead of `as_secs() * 1000` which results in lost precision.

Also convert duration integers to smaller integers with the help of `TryFrom` in order to catch overflows and panic. As said on slack, we might not want to bloat the API with `Result` types. But I felt that silently using a possibly wildly different delay than the given is also bad. So panicking and documenting the panic is the best solution IMO.

People should use this API with mostly hardcoded durations anyway, so they will see they use the wrong delays directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/38)
<!-- Reviewable:end -->
