### PR TITLE
Configure mandatory service settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Add support for configuring the service SID info.
+- Add support for changing mandatory configuration settings on service.
 - Add support for service failure actions. (See: `ServiceFailureActions`, 
   `Service::update_failure_actions`, `Service::get_failure_actions`, 
   `Service::set_failure_actions_on_non_crash_failures`, 
@@ -14,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Bumped the MSRV to 1.34, because of err-derive upgrade which depend on quote, to use
   `Duration::as_millis()` and the `TryFrom` trait.
+- Breaking: `ServiceManager::create_service()` now expects a borrowed `ServiceInfo` argument.
 
 ## [0.2.0] - 2019-04-01
 ### Added

--- a/examples/install_service.rs
+++ b/examples/install_service.rs
@@ -28,7 +28,7 @@ fn main() -> windows_service::Result<()> {
         account_name: None, // run as System
         account_password: None,
     };
-    let _service = service_manager.create_service(service_info, ServiceAccess::empty())?;
+    let _service = service_manager.create_service(&service_info, ServiceAccess::empty())?;
     Ok(())
 }
 

--- a/examples/service_failure_actions.rs
+++ b/examples/service_failure_actions.rs
@@ -40,7 +40,7 @@ fn main() -> windows_service::Result<()> {
 
     println!("Create or open the service {}", SERVICE_NAME);
     let service = service_manager
-        .create_service(service_info, service_access)
+        .create_service(&service_info, service_access)
         .or(service_manager.open_service(SERVICE_NAME, service_access))?;
 
     let actions = vec![


### PR DESCRIPTION
Previously, for an existing service, you could only configure optional settings. There was no way to configure the mandatory settings for an existing service.

These changes add the required functionality to configure the mandatory settings on an existing service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/40)
<!-- Reviewable:end -->
