### PR TITLE
Add support to pause and continue services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `Service::update_failure_actions`, `Service::get_failure_actions`, 
   `Service::set_failure_actions_on_non_crash_failures`, 
   `Service::get_failure_actions_on_non_crash_failures`)
+- Add support to pause and continue services. (See: `Service::pause` and `Service::resume`)
 
 ### Changed
 - Bumped the MSRV to 1.34, because of err-derive upgrade which depend on quote, to use

--- a/examples/pause_continue.rs
+++ b/examples/pause_continue.rs
@@ -1,0 +1,41 @@
+/// This is an example program that demonstrates how to pause and resume a given service.
+///
+/// Run in command prompt as admin:
+///
+/// `pause_continue.exe SERVICE_NAME`
+///
+/// Replace the `SERVICE_NAME` placeholder above with the name of the service that the program
+/// should manipulate. By default the program manipulates a WMI system service (Winmgmt) when the
+/// first argument is omitted.
+
+#[cfg(windows)]
+fn main() -> windows_service::Result<()> {
+    use std::env;
+    use windows_service::{
+        service::ServiceAccess,
+        service_manager::{ServiceManager, ServiceManagerAccess},
+    };
+
+    let service_name = env::args().nth(1).unwrap_or("Winmgmt".to_owned());
+
+    let manager_access = ServiceManagerAccess::CONNECT;
+    let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
+
+    let service = service_manager.open_service(&service_name, ServiceAccess::PAUSE_CONTINUE)?;
+
+    println!("Pause {}", service_name);
+    let paused_state = service.pause()?;
+    println!("{:?}", paused_state.current_state);
+
+    println!("Resume {}", service_name);
+    let resumed_state = service.resume()?;
+    println!("{:?}", resumed_state.current_state);
+
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn main() {
+    panic!("This program is only intended to run on Windows.");
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -1329,6 +1329,30 @@ impl Service {
         self.send_control_command(ServiceControl::Stop)
     }
 
+    /// Pause the service.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use windows_service::service::ServiceAccess;
+    /// use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+    ///
+    /// # fn main() -> windows_service::Result<()> {
+    /// let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)?;
+    /// let my_service = manager.open_service("my_service", ServiceAccess::PAUSE_CONTINUE)?;
+    /// my_service.pause()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn pause(&self) -> crate::Result<ServiceStatus> {
+        self.send_control_command(ServiceControl::Pause)
+    }
+
+    /// Resume the paused service.
+    pub fn resume(&self) -> crate::Result<ServiceStatus> {
+        self.send_control_command(ServiceControl::Continue)
+    }
+
     /// Get the service status from the system.
     pub fn query_status(&self) -> crate::Result<ServiceStatus> {
         let mut raw_status = unsafe { mem::zeroed::<winsvc::SERVICE_STATUS>() };
@@ -1459,7 +1483,10 @@ impl Service {
         Ok(result)
     }
 
-    pub fn set_config_service_sid_info(&self, mut service_sid_type: ServiceSidType) -> crate::Result<()> {
+    pub fn set_config_service_sid_info(
+        &self,
+        mut service_sid_type: ServiceSidType,
+    ) -> crate::Result<()> {
         // The structure we need to pass in is `SERVICE_SID_INFO`.
         // It has a single member that specifies the new SID type, and as such,
         // we can get away with not explicitly creating a structure in Rust.


### PR DESCRIPTION
This PR adds support to pause and continue services using programmatic API.

Since `continue` is a reserved keyword in Rust, I opt-in to use `resume` instead in`Service` interface. Windows Services Pane UI also refers to "continue" as "resume", while programmatic APIs mostly use pause/continue pair, such as in permissons mask -- `PAUSE_CONTINUE`.

Fixes #41

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/42)
<!-- Reviewable:end -->
