### PR TITLE
Retrieve pid when querying service status

### DIFF
--- a/examples/ping_service.rs
+++ b/examples/ping_service.rs
@@ -101,6 +101,7 @@ mod ping_service {
             exit_code: ServiceExitCode::Win32(0),
             checkpoint: 0,
             wait_hint: Duration::default(),
+            pid: None,
         })?;
 
         // For demo purposes this service sends a UDP packet once a second.
@@ -131,6 +132,7 @@ mod ping_service {
             exit_code: ServiceExitCode::Win32(0),
             checkpoint: 0,
             wait_hint: Duration::default(),
+            pid: None,
         })?;
 
         Ok(())

--- a/examples/ping_service.rs
+++ b/examples/ping_service.rs
@@ -101,7 +101,7 @@ mod ping_service {
             exit_code: ServiceExitCode::Win32(0),
             checkpoint: 0,
             wait_hint: Duration::default(),
-            pid: None,
+            process_id: None,
         })?;
 
         // For demo purposes this service sends a UDP packet once a second.
@@ -132,7 +132,7 @@ mod ping_service {
             exit_code: ServiceExitCode::Win32(0),
             checkpoint: 0,
             wait_hint: Duration::default(),
-            pid: None,
+            process_id: None,
         })?;
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@
 //!         // Only used for pending states, otherwise must be zero
 //!         wait_hint: Duration::default(),
 //!         // Unused for setting status
-//!         pid: None,
+//!         process_id: None,
 //!     };
 //!
 //!     // Tell the system that the service is running now

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,8 @@
 //!         checkpoint: 0,
 //!         // Only used for pending states, otherwise must be zero
 //!         wait_hint: Duration::default(),
+//!         // Unused for setting status
+//!         pid: None,
 //!     };
 //!
 //!     // Tell the system that the service is running now

--- a/src/service.rs
+++ b/src/service.rs
@@ -1237,7 +1237,7 @@ pub struct ServiceStatus {
 
     /// Process ID of the service
     /// This is only retrieved when querying the service status.
-    pub pid: Option<u32>,
+    pub process_id: Option<u32>,
 }
 
 impl ServiceStatus {
@@ -1270,7 +1270,7 @@ impl ServiceStatus {
             exit_code: ServiceExitCode::from(&raw),
             checkpoint: raw.dwCheckPoint,
             wait_hint: Duration::from_millis(raw.dwWaitHint as u64),
-            pid: None,
+            process_id: None,
         })
     }
 
@@ -1282,7 +1282,7 @@ impl ServiceStatus {
     /// Returns an error if the `dwCurrentState` field does not represent a valid [`ServiceState`].
     fn from_raw_ex(raw: winsvc::SERVICE_STATUS_PROCESS) -> Result<Self, ParseRawError> {
         let current_state = ServiceState::from_raw(raw.dwCurrentState)?;
-        let pid = match current_state {
+        let process_id = match current_state {
             ServiceState::Running => Some(raw.dwProcessId),
             _ => None,
         };
@@ -1293,7 +1293,7 @@ impl ServiceStatus {
             checkpoint: raw.dwCheckPoint,
             wait_hint: Duration::from_millis(raw.dwWaitHint as u64),
             current_state,
-            pid,
+            process_id,
         })
     }
 }


### PR DESCRIPTION
Uses `QueryServiceStatusEx` to obtain service pid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/44)
<!-- Reviewable:end -->
