### PR TITLE
update err drive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ default-target = "x86_64-pc-windows-msvc"
 
 [target.'cfg(windows)'.dependencies]
 bitflags = "1.2"
-err-derive = "0.2.1"
+err-derive = "0.2.4"
 winapi = { git = "https://github.com/mullvad/winapi-rs.git", rev = "4bcf5cab87124bbeef8c1a445137494d874f8082", features = ["dbt", "std", "winbase", "winerror", "winsvc"] }
 widestring = "0.4.0"


### PR DESCRIPTION
pr updates err-derive version to latest. fixes build issue on version `0.2.1`  patched at https://gitlab.com/torkleyy/err-derive/-/commit/49464f46e686a51d2d8cb0f210d6cc2785a83f41.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/46)
<!-- Reviewable:end -->
