### PR TITLE
Vendor in unpublished winapi-rs code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ default-target = "x86_64-pc-windows-msvc"
 [target.'cfg(windows)'.dependencies]
 bitflags = "1.2"
 err-derive = "0.2.4"
-winapi = { git = "https://github.com/mullvad/winapi-rs.git", rev = "4bcf5cab87124bbeef8c1a445137494d874f8082", features = ["dbt", "std", "winbase", "winerror", "winsvc"] }
+winapi = { version = "0.3.8", features = ["dbt", "std", "winbase", "winerror", "winsvc"] }
 widestring = "0.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,3 +262,4 @@ pub mod service_dispatcher;
 
 mod double_nul_terminated;
 mod shell_escape;
+mod winsvc_vendored;

--- a/src/service.rs
+++ b/src/service.rs
@@ -13,10 +13,11 @@ use winapi::shared::guiddef::{IsEqualGUID, GUID};
 use winapi::shared::minwindef::DWORD;
 use winapi::shared::winerror::{ERROR_SERVICE_SPECIFIC_ERROR, NO_ERROR};
 use winapi::um::winbase::INFINITE;
-use winapi::um::{dbt, winnt, winsvc, winuser};
+use winapi::um::{dbt, winnt, winuser};
 
 use crate::sc_handle::ScHandle;
 use crate::shell_escape;
+use crate::winsvc_vendored as winsvc;
 use crate::{double_nul_terminated, Error};
 
 bitflags::bitflags! {

--- a/src/winsvc_vendored.rs
+++ b/src/winsvc_vendored.rs
@@ -1,0 +1,31 @@
+#![allow(non_snake_case)]
+#![allow(non_camel_case_types)]
+
+use winapi::shared::minwindef::{BOOL, DWORD};
+use winapi::shared::ntdef::LPWSTR;
+use winapi::{ENUM, STRUCT};
+
+pub use winapi::um::winsvc::*;
+
+ENUM! {enum SC_ACTION_TYPE {
+    SC_ACTION_NONE = 0,
+    SC_ACTION_RESTART = 1,
+    SC_ACTION_REBOOT = 2,
+    SC_ACTION_RUN_COMMAND = 3,
+}}
+STRUCT! {struct SC_ACTION {
+    Type: SC_ACTION_TYPE,
+    Delay: DWORD,
+}}
+pub type LPSC_ACTION = *mut SC_ACTION;
+STRUCT! {struct SERVICE_FAILURE_ACTIONSW {
+    dwResetPeriod: DWORD,
+    lpRebootMsg: LPWSTR,
+    lpCommand: LPWSTR,
+    cActions: DWORD,
+    lpsaActions: LPSC_ACTION,
+}}
+
+STRUCT! {struct SERVICE_FAILURE_ACTIONS_FLAG {
+    fFailureActionsOnNonCrashFailures: BOOL,
+}}


### PR DESCRIPTION
The repo cannot be released at the moment, because we depend on changes to the master branch of [winapi-rs](https://github.com/retep998/winapi-rs) that have not yet been released. So let's include those changes in this repository and depend on the last release of `winapi-rs`.

Fixes issue #43.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/49)
<!-- Reviewable:end -->
