### PR TITLE
service: Replace std::mem::* calls by std::mem::MaybeUninit.

### DIFF
--- a/examples/pause_continue.rs
+++ b/examples/pause_continue.rs
@@ -31,7 +31,6 @@ fn main() -> windows_service::Result<()> {
     let resumed_state = service.resume()?;
     println!("{:?}", resumed_state.current_state);
 
-
     Ok(())
 }
 

--- a/examples/service_config.rs
+++ b/examples/service_config.rs
@@ -11,10 +11,15 @@ fn main() -> windows_service::Result<()> {
     let manager_access = ServiceManagerAccess::CONNECT;
     let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
 
-    let service = service_manager.open_service(service_name, ServiceAccess::QUERY_CONFIG)?;
+    let service = service_manager.open_service(
+        service_name,
+        ServiceAccess::QUERY_CONFIG | ServiceAccess::QUERY_STATUS,
+    )?;
 
     let config = service.query_config()?;
+    let status = service.query_status()?;
     println!("{:#?}", config);
+    println!("{:#?}", status);
     Ok(())
 }
 


### PR DESCRIPTION
I used your library in https://github.com/timberio/vector/pull/2896 to implement windows service support.

The command-line supports a `service status` sub-command. However, it looks like the `query_config` call is now crashing with a recent version of `rustc` (it was working when I initially submitted the PR).

Using `std::mem::MaybeUninit` to safely initialize raw memory seems to fix the issue.

This change should also address #45 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/52)
<!-- Reviewable:end -->
