### PR TITLE
Fix seg fault when calling to QueryServiceConfig* functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Fix segmentation fault in `Service` functions, that query service config, by moving buffer 
+  allocation on heap.
 
 ## [0.3.0] - 2020-06-18
 ### Added

--- a/src/service.rs
+++ b/src/service.rs
@@ -1424,7 +1424,7 @@ impl Service {
     /// Get the service config from the system.
     pub fn query_config(&self) -> crate::Result<ServiceConfig> {
         // As per docs, the maximum size of data buffer used by QueryServiceConfigW is 8K
-        let mut data = [0u8; MAX_QUERY_BUFFER_SIZE];
+        let mut data = vec![0u8; MAX_QUERY_BUFFER_SIZE];
         let mut bytes_written: u32 = 0;
 
         let success = unsafe {
@@ -1512,7 +1512,7 @@ impl Service {
     /// Query the system for the boolean indication that the service is configured to run failure
     /// actions on non-crash failures.
     pub fn get_failure_actions_on_non_crash_failures(&self) -> crate::Result<bool> {
-        let mut data = [0u8; MAX_QUERY_BUFFER_SIZE];
+        let mut data = vec![0u8; MAX_QUERY_BUFFER_SIZE];
 
         let raw_failure_actions_flag: winsvc::SERVICE_FAILURE_ACTIONS_FLAG = unsafe {
             self.query_config2(winsvc::SERVICE_CONFIG_FAILURE_ACTIONS_FLAG, &mut data)
@@ -1547,7 +1547,7 @@ impl Service {
     /// Query the configured failure actions for the service.
     pub fn get_failure_actions(&self) -> crate::Result<ServiceFailureActions> {
         unsafe {
-            let mut data = [0u8; MAX_QUERY_BUFFER_SIZE];
+            let mut data = vec![0u8; MAX_QUERY_BUFFER_SIZE];
 
             let raw_failure_actions: winsvc::SERVICE_FAILURE_ACTIONSW = self
                 .query_config2(winsvc::SERVICE_CONFIG_FAILURE_ACTIONS, &mut data)
@@ -1657,11 +1657,7 @@ impl Service {
     }
 
     /// Private helper to query the optional configuration parameters of windows services.
-    unsafe fn query_config2<T: Copy>(
-        &self,
-        kind: DWORD,
-        data: &mut [u8; MAX_QUERY_BUFFER_SIZE],
-    ) -> io::Result<T> {
+    unsafe fn query_config2<T: Copy>(&self, kind: DWORD, data: &mut [u8]) -> io::Result<T> {
         let mut bytes_written: u32 = 0;
 
         let success = winsvc::QueryServiceConfig2W(


### PR DESCRIPTION
Current `master` is broken. Functions that query service config seg fault at random:

```
$ RUST_BACKTRACE=1 cargo run --example service_config
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `target\debug\examples\service_config.exe`
error: process didn't exit successfully: `target\debug\examples\service_config.exe` (exit code: 0xc0000005, STATUS_ACCESS_VIOLATION)
Segmentation fault
```

I suspect that the problem is that we pass an 8K buffer allocated on stack into `QueryServiceConfig*` functions, which expect a heap allocated memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/55)
<!-- Reviewable:end -->
