### PR TITLE
Use impl Trait instead of generic parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Breaking: `ServiceDependency::from_system_identifier()`, `ServiceManager::new()`, 
+  `ServiceManager::local_computer()`, `ServiceManager::remote_computer()` now take 
+  `impl AsRef<OsStr>` arguments.
 
 
 ## [0.3.1] - 2020-10-27

--- a/src/service.rs
+++ b/src/service.rs
@@ -151,7 +151,7 @@ impl ServiceDependency {
         }
     }
 
-    pub fn from_system_identifier<S: AsRef<OsStr>>(identifier: S) -> Self {
+    pub fn from_system_identifier(identifier: impl AsRef<OsStr>) -> Self {
         let group_prefix: u16 = '+' as u16;
         let mut iter = identifier.as_ref().encode_wide().peekable();
 

--- a/src/service_manager.rs
+++ b/src/service_manager.rs
@@ -35,9 +35,9 @@ impl ServiceManager {
     /// * `machine` - The name of machine. Pass `None` to connect to local machine.
     /// * `database` - The name of database to connect to. Pass `None` to connect to active
     ///   database.
-    fn new<M: AsRef<OsStr>, D: AsRef<OsStr>>(
-        machine: Option<M>,
-        database: Option<D>,
+    fn new(
+        machine: Option<impl AsRef<OsStr>>,
+        database: Option<impl AsRef<OsStr>>,
         request_access: ServiceManagerAccess,
     ) -> Result<Self> {
         let machine_name = to_wide(machine).map_err(Error::InvalidMachineName)?;
@@ -66,8 +66,8 @@ impl ServiceManager {
     /// * `database` - The name of database to connect to. Pass `None` to connect to active
     ///   database.
     /// * `request_access` - Desired access permissions.
-    pub fn local_computer<D: AsRef<OsStr>>(
-        database: Option<D>,
+    pub fn local_computer(
+        database: Option<impl AsRef<OsStr>>,
         request_access: ServiceManagerAccess,
     ) -> Result<Self> {
         ServiceManager::new(None::<&OsStr>, database, request_access)
@@ -81,9 +81,9 @@ impl ServiceManager {
     /// * `database` - The name of database to connect to. Pass `None` to connect to active
     ///   database.
     /// * `request_access` - desired access permissions.
-    pub fn remote_computer<M: AsRef<OsStr>, D: AsRef<OsStr>>(
-        machine: M,
-        database: Option<D>,
+    pub fn remote_computer(
+        machine: impl AsRef<OsStr>,
+        database: Option<impl AsRef<OsStr>>,
         request_access: ServiceManagerAccess,
     ) -> Result<Self> {
         ServiceManager::new(Some(machine), database, request_access)


### PR DESCRIPTION
This PR migrates the rest of the codebase to `impl Trait` in places where we used to have generic parameter. This is a breaking change & should be merged after all other PR have been merged & released as a part of major release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/56)
<!-- Reviewable:end -->
