### PR TITLE
Add API to expose ServiceStatusHandle as_raw_handle

### DIFF
--- a/src/service_control_handler.rs
+++ b/src/service_control_handler.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsStr;
 use std::io;
 use std::os::raw::c_void;
+use std::os::windows::prelude::{RawHandle, AsRawHandle};
 use widestring::WideCString;
 use windows_sys::Win32::{
     Foundation::{ERROR_CALL_NOT_IMPLEMENTED, NO_ERROR},
@@ -30,6 +31,15 @@ impl ServiceStatusHandle {
         }
     }
 }
+
+impl AsRawHandle for ServiceStatusHandle {
+    /// Get access to the raw handle to use in other Windows APIs
+    fn as_raw_handle(&self) -> RawHandle {
+        self.0 as _
+    }
+}
+
+
 
 // Underlying SERVICE_STATUS_HANDLE is thread safe.
 // See remarks section for more info:


### PR DESCRIPTION
This is needed for users who want to pass SERVICE_STATUS_HANDLE into
other Windows APIs such as the RegisterPowerSettingNotification API

https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-registerpowersettingnotification

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/69)
<!-- Reviewable:end -->
