### PR TITLE
Revert Service::start back to using generics over impl trait

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -1376,7 +1376,7 @@ impl Service {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn start(&self, service_arguments: &[impl AsRef<OsStr>]) -> crate::Result<()> {
+    pub fn start<S: AsRef<OsStr>>(&self, service_arguments: &[S]) -> crate::Result<()> {
         let wide_service_arguments = service_arguments
             .iter()
             .map(|s| WideCString::from_os_str(s).map_err(|_| Error::StartArgumentHasNulByte))


### PR DESCRIPTION
Reverting back to how the signature looked in version 0.2.
Allows calling it without any arguments in a more ergonomic way.
`service.start::<OsString>(&[])` should now work again.

I don't see any downsides of this. The impl trait way of writing it does not really have any benefits, except it does not litter functions with generics. But here it's just a single generic, and it has an actual use case. Even if there are ways of calling `Service::start` without arguments anyway, it is more ergonomic with generics.

Fixes #51 