### PR TITLE
Bug fixes, features and some public API changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-target = "x86_64-pc-windows-msvc"
 
 [target.'cfg(windows)'.dependencies]
 bitflags = "1.3"
-err-derive = "0.3.1"
+thiserror = "1"
 widestring = "1"
 
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,11 @@ err-derive = "0.3.1"
 widestring = "1"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.36.1"
+version = "0.45"
 features = [
     "Win32_Foundation",
     "Win32_Security",
+    "Win32_Storage_FileSystem",
     "Win32_System_Power",
     "Win32_System_RemoteDesktop",
     "Win32_System_Services",

--- a/examples/install_service.rs
+++ b/examples/install_service.rs
@@ -1,6 +1,6 @@
 #[cfg(windows)]
 fn main() -> windows_service::Result<()> {
-    use std::ffi::OsString;
+    use std::ffi::OsStr;
     use windows_service::{
         service::{ServiceAccess, ServiceErrorControl, ServiceInfo, ServiceStartType, ServiceType},
         service_manager::{ServiceManager, ServiceManagerAccess},
@@ -16,15 +16,15 @@ fn main() -> windows_service::Result<()> {
         .unwrap()
         .with_file_name("ping_service.exe");
 
-    let service_info = ServiceInfo {
-        name: OsString::from("ping_service"),
-        display_name: OsString::from("Ping service"),
+    let service_info: ServiceInfo<&OsStr> = ServiceInfo {
+        name: OsStr::new("ping_service"),
+        display_name: OsStr::new("Ping service"),
         service_type: ServiceType::OWN_PROCESS,
         start_type: ServiceStartType::OnDemand,
         error_control: ServiceErrorControl::Normal,
-        executable_path: service_binary_path,
-        launch_arguments: vec![],
-        dependencies: vec![],
+        executable_path: &service_binary_path,
+        launch_arguments: &[],
+        dependencies: &[],
         account_name: None, // run as System
         account_password: None,
     };

--- a/examples/pause_continue.rs
+++ b/examples/pause_continue.rs
@@ -23,11 +23,11 @@ fn main() -> windows_service::Result<()> {
 
     let service = service_manager.open_service(&service_name, ServiceAccess::PAUSE_CONTINUE)?;
 
-    println!("Pause {}", service_name);
+    println!("Pause {service_name}");
     let paused_state = service.pause()?;
     println!("{:?}", paused_state.current_state);
 
-    println!("Resume {}", service_name);
+    println!("Resume {service_name}");
     let resumed_state = service.resume()?;
     println!("{:?}", resumed_state.current_state);
 

--- a/examples/service_config.rs
+++ b/examples/service_config.rs
@@ -14,7 +14,7 @@ fn main() -> windows_service::Result<()> {
     let service = service_manager.open_service(service_name, ServiceAccess::QUERY_CONFIG)?;
 
     let config = service.query_config()?;
-    println!("{:#?}", config);
+    println!("{config:#?}");
     Ok(())
 }
 

--- a/examples/service_failure_actions.rs
+++ b/examples/service_failure_actions.rs
@@ -1,6 +1,6 @@
 #[cfg(windows)]
 fn main() -> windows_service::Result<()> {
-    use std::ffi::OsString;
+    use std::ffi::{OsStr, OsString};
     use std::time::Duration;
     use windows_service::{
         service::{
@@ -20,15 +20,15 @@ fn main() -> windows_service::Result<()> {
         .unwrap()
         .with_file_name("service_failure_actions.exe");
 
-    let service_info = ServiceInfo {
-        name: OsString::from(SERVICE_NAME),
-        display_name: OsString::from("Service Failure Actions Example"),
+    let service_info: ServiceInfo<&OsStr> = ServiceInfo {
+        name: OsStr::new(SERVICE_NAME),
+        display_name: OsStr::new("Service Failure Actions Example"),
         service_type: ServiceType::OWN_PROCESS,
         start_type: ServiceStartType::OnDemand,
         error_control: ServiceErrorControl::Normal,
-        executable_path: service_binary_path,
-        launch_arguments: vec![],
-        dependencies: vec![],
+        executable_path: &service_binary_path,
+        launch_arguments: &[],
+        dependencies: &[],
         account_name: None, // run as System
         account_password: None,
     };
@@ -76,11 +76,9 @@ fn main() -> windows_service::Result<()> {
 
     println!("Query failure actions on non-crash failures enabled");
     let failure_actions_flag = service.get_failure_actions_on_non_crash_failures()?;
-    println!(
-        "Failure actions on non-crash failures enabled: {failure_actions_flag}"
-    );
+    println!("Failure actions on non-crash failures enabled: {failure_actions_flag}");
 
-    println!("Delete the service {SERVICE_NAME}");
+    println!("Mark the service {SERVICE_NAME} for deletion");
     service.delete()?;
 
     Ok(())

--- a/examples/service_failure_actions.rs
+++ b/examples/service_failure_actions.rs
@@ -38,7 +38,7 @@ fn main() -> windows_service::Result<()> {
         | ServiceAccess::START
         | ServiceAccess::DELETE;
 
-    println!("Create or open the service {}", SERVICE_NAME);
+    println!("Create or open the service {SERVICE_NAME}");
     let service = service_manager
         .create_service(&service_info, service_access)
         .or(service_manager.open_service(SERVICE_NAME, service_access))?;
@@ -69,7 +69,7 @@ fn main() -> windows_service::Result<()> {
 
     println!("Query failure actions");
     let updated_failure_actions = service.get_failure_actions()?;
-    println!("{:#?}", updated_failure_actions);
+    println!("{updated_failure_actions:#?}");
 
     println!("Enable failure actions on non-crash failures");
     service.set_failure_actions_on_non_crash_failures(true)?;
@@ -77,11 +77,10 @@ fn main() -> windows_service::Result<()> {
     println!("Query failure actions on non-crash failures enabled");
     let failure_actions_flag = service.get_failure_actions_on_non_crash_failures()?;
     println!(
-        "Failure actions on non-crash failures enabled: {}",
-        failure_actions_flag
+        "Failure actions on non-crash failures enabled: {failure_actions_flag}"
     );
 
-    println!("Delete the service {}", SERVICE_NAME);
+    println!("Delete the service {SERVICE_NAME}");
     service.delete()?;
 
     Ok(())

--- a/examples/uninstall_service.rs
+++ b/examples/uninstall_service.rs
@@ -1,10 +1,10 @@
 #[cfg(windows)]
 fn main() -> windows_service::Result<()> {
-    use std::{thread, time::Duration};
     use windows_service::{
         service::{ServiceAccess, ServiceState},
         service_manager::{ServiceManager, ServiceManagerAccess},
     };
+    use windows_sys::Win32::Foundation::ERROR_SERVICE_DOES_NOT_EXIST;
 
     let manager_access = ServiceManagerAccess::CONNECT;
     let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
@@ -12,14 +12,26 @@ fn main() -> windows_service::Result<()> {
     let service_access = ServiceAccess::QUERY_STATUS | ServiceAccess::STOP | ServiceAccess::DELETE;
     let service = service_manager.open_service("ping_service", service_access)?;
 
-    let service_status = service.query_status()?;
-    if service_status.current_state != ServiceState::Stopped {
+    // The service will be marked for deletion as long as this function call succeeds.
+    // However, it will not be deleted from the database until it is stopped and all open handles to it are closed.
+    service.delete()?;
+    // Our handle to it is not closed yet. So we can still query it.
+    if service.query_status()?.current_state != ServiceState::Stopped {
+        // If the service cannot be stopped, it will be deleted when the system restarts.
         service.stop()?;
-        // Wait for service to stop
-        thread::sleep(Duration::from_secs(1));
+    }
+    // Explicitly close our open handle to the service. This is automatically called when `service` goes out of scope.
+    drop(service);
+
+    // Check if the service is deleted.
+    if let Err(windows_service::Error::Winapi(e)) =
+        service_manager.open_service("ping_service", ServiceAccess::QUERY_STATUS)
+    {
+        if e.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST as i32) {
+            println!("ping_service is deleted.")
+        }
     }
 
-    service.delete()?;
     Ok(())
 }
 

--- a/examples/uninstall_service.rs
+++ b/examples/uninstall_service.rs
@@ -24,10 +24,8 @@ fn main() -> windows_service::Result<()> {
     drop(service);
 
     // Check if the service is deleted.
-    if let Err(windows_service::Error::Winapi(e)) =
-        service_manager.open_service("ping_service", ServiceAccess::QUERY_STATUS)
-    {
-        if e.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST as i32) {
+    if let Err(e) = service_manager.open_service("ping_service", ServiceAccess::QUERY_STATUS) {
+        if e.is_os_error(ERROR_SERVICE_DOES_NOT_EXIST as i32) {
             println!("ping_service is deleted.")
         }
     }

--- a/src/double_nul_terminated.rs
+++ b/src/double_nul_terminated.rs
@@ -20,9 +20,9 @@ pub fn from_vec(source: &[impl AsRef<OsStr>]) -> Result<Option<WideString>, Cont
         for s in source {
             let checked_str = WideCString::from_os_str(s)?;
             wide.push_slice(checked_str);
-            wide.push_slice(&[0]);
+            wide.push_slice([0]);
         }
-        wide.push_slice(&[0]);
+        wide.push_slice([0]);
         Ok(Some(wide))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,84 +178,83 @@
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(err_derive::Error, Debug)]
-#[error(no_from)]
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
     /// Account name contains a nul byte.
-    #[error(display = "Account name contains a nul byte")]
+    #[error("Account name contains a nul byte")]
     AccountNameHasNulByte,
 
     /// Account password contains a nul byte.
-    #[error(display = "Account password contains a nul byte")]
+    #[error("Account password contains a nul byte")]
     AccountPasswordHasNulByte,
 
     /// Display name contains a nul byte.
-    #[error(display = "Display name contains a nul byte")]
+    #[error("Display name contains a nul byte")]
     DisplayNameHasNulByte,
 
     /// Database name contains a nul byte.
-    #[error(display = "Database name contains a nul byte")]
+    #[error("Database name contains a nul byte")]
     DatabaseNameHasNulByte,
 
     /// Executable path contains a nul byte.
-    #[error(display = "Executable path contains a nul byte")]
+    #[error("Executable path contains a nul byte")]
     ExecutablePathHasNulByte,
 
     /// Launch arguments contains a nul byte.
-    #[error(display = "Launch argument at index {} contains a nul byte", _0)]
+    #[error("Launch argument at index {0} contains a nul byte")]
     LaunchArgumentHasNulByte(usize),
 
     /// Launch arguments are not supported for kernel drivers.
-    #[error(display = "Kernel drivers do not support launch arguments")]
+    #[error("Kernel drivers do not support launch arguments")]
     LaunchArgumentsNotSupported,
 
     /// Dependency name contains a nul byte.
-    #[error(display = "Dependency name contains a nul byte")]
+    #[error("Dependency name contains a nul byte")]
     DependencyHasNulByte,
 
     /// Machine name contains a nul byte.
-    #[error(display = "Machine name contains a nul byte")]
+    #[error("Machine name contains a nul byte")]
     MachineNameHasNulByte,
 
     /// Service name contains a nul byte.
-    #[error(display = "Service name contains a nul byte")]
+    #[error("Service name contains a nul byte")]
     ServiceNameHasNulByte,
 
     /// Start argument contains a nul byte.
-    #[error(display = "Start argument contains a nul byte")]
+    #[error("Start argument contains a nul byte")]
     StartArgumentHasNulByte,
 
     /// Invalid raw representation of [`ServiceState`](service::ServiceState).
-    #[error(display = "Invalid service state value")]
-    InvalidServiceState(#[error(source)] service::ParseRawError),
+    #[error("Invalid service state value")]
+    InvalidServiceState(#[source] service::ParseRawError),
 
     /// Invalid raw representation of [`ServiceStartType`](service::ServiceStartType).
-    #[error(display = "Invalid service start value")]
-    InvalidServiceStartType(#[error(source)] service::ParseRawError),
+    #[error("Invalid service start value")]
+    InvalidServiceStartType(#[source] service::ParseRawError),
 
     /// Invalid raw representation of [`ServiceErrorControl`](service::ServiceErrorControl).
-    #[error(display = "Invalid service error control value")]
-    InvalidServiceErrorControl(#[error(source)] service::ParseRawError),
+    #[error("Invalid service error control value")]
+    InvalidServiceErrorControl(#[source] service::ParseRawError),
 
     /// Invalid raw representation of [`ServiceActionType`](service::ServiceActionType).
-    #[error(display = "Invalid service action type")]
-    InvalidServiceActionType(#[error(source)] service::ParseRawError),
+    #[error("Invalid service action type")]
+    InvalidServiceActionType(#[source] service::ParseRawError),
 
     /// Reboot message contains a nul byte.
-    #[error(display = "Service action failures reboot message contains a nul byte")]
+    #[error("Service action failures reboot message contains a nul byte")]
     ServiceActionFailuresRebootMessageHasNulByte,
 
     /// Command contains a nul byte.
-    #[error(display = "Service action failures command contains a nul byte")]
+    #[error("Service action failures command contains a nul byte")]
     ServiceActionFailuresCommandHasNulByte,
 
     /// Service description contains a nul byte.
-    #[error(display = "Service description contains a nul byte")]
+    #[error("Service description contains a nul byte")]
     ServiceDescriptionHasNulByte,
 
-    /// IO error when calling winapi
-    #[error(display = "IO error in winapi call")]
-    Winapi(#[error(source)] std::io::Error),
+    /// IO error when calling win32 API
+    #[error("IO error in win32 API call")]
+    Winapi(#[source] std::io::Error),
 }
 
 impl Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,6 +258,26 @@ pub enum Error {
     Winapi(#[error(source)] std::io::Error),
 }
 
+impl Error {
+    /// Return if an error from win32 API call matches the specific OS error code.
+    ///
+    /// To find the names of OS error codes that a specific win32 API call may return,
+    /// browse the [official docs]. They are also defined in `windows_sys` crate.
+    ///
+    /// For example, [`windows_sys::Win32::Foundation::ERROR_SERVICE_DOES_NOT_EXIST`] may
+    /// be returned by [`service_manager::ServiceManager::open_service`].
+    ///
+    /// [official docs]: https://learn.microsoft.com/en-us/windows/win32/api/winsvc/#functions
+    pub fn is_os_error(&self, error_code: i32) -> bool {
+        if let Self::Winapi(e) = self {
+            if e.raw_os_error() == Some(error_code) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
 mod sc_handle;
 pub mod service;
 pub mod service_control_handler;

--- a/src/service.rs
+++ b/src/service.rs
@@ -454,7 +454,7 @@ impl RawServiceInfo {
             .iter()
             .map(|dependency| dependency.to_system_identifier())
             .collect();
-        let joined_dependencies = double_nul_terminated::from_vec(&dependency_identifiers)
+        let joined_dependencies = double_nul_terminated::from_slice(&dependency_identifiers)
             .map_err(|_| Error::DependencyHasNulByte)?;
 
         Ok(Self {

--- a/src/service.rs
+++ b/src/service.rs
@@ -1692,6 +1692,26 @@ impl Service {
         }
     }
 
+    /// Set if an auto-start service should be delayed.
+    ///
+    /// If true, the service is started after other auto-start services are started plus a short delay.
+    /// Otherwise, the service is started during system boot. The default is false. This setting is
+    /// ignored unless the service is an auto-start service.
+    ///
+    /// Required permission: [`ServiceAccess::CHANGE_CONFIG`].
+    pub fn set_delayed_auto_start(&self, delayed: bool) -> crate::Result<()> {
+        let mut delayed = Services::SERVICE_DELAYED_AUTO_START_INFO {
+            fDelayedAutostart: delayed as i32,
+        };
+        unsafe {
+            self.change_config2(
+                Services::SERVICE_CONFIG_DELAYED_AUTO_START_INFO,
+                &mut delayed,
+            )
+            .map_err(Error::Winapi)
+        }
+    }
+
     /// Private helper to send the control commands to the system.
     fn send_control_command(&self, command: ServiceControl) -> crate::Result<ServiceStatus> {
         let mut raw_status = unsafe { mem::zeroed::<Services::SERVICE_STATUS>() };

--- a/src/service.rs
+++ b/src/service.rs
@@ -1766,15 +1766,15 @@ fn to_wide_slice(
     }
 }
 
-#[derive(err_derive::Error, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum ParseRawError {
-    #[error(display = "Invalid integer value for the target type: {}", _0)]
+    #[error("Invalid integer value for the target type: {0}")]
     InvalidInteger(u32),
 
-    #[error(display = "Invalid integer value for the target type: {}", _0)]
+    #[error("Invalid integer value for the target type: {0}")]
     InvalidIntegerSigned(i32),
 
-    #[error(display = "Invalid GUID value for the target type: {}", _0)]
+    #[error("Invalid GUID value for the target type: {0}")]
     InvalidGuid(String),
 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -1452,8 +1452,13 @@ impl Service {
         }
     }
 
-    /// Delete the service from system registry.
-    pub fn delete(self) -> crate::Result<()> {
+    /// Mark the service for deletion from the service control manager database.
+    ///
+    /// The database entry is not removed until all open handles to the service have been closed
+    /// and the service is stopped. If the service is not or cannot be stopped, the database entry
+    /// is removed when the system is restarted. This function will return an error if the service
+    /// has already been marked for deletion.
+    pub fn delete(&self) -> crate::Result<()> {
         let success = unsafe { Services::DeleteService(self.service_handle.raw_handle()) };
         if success == 0 {
             Err(Error::Winapi(io::Error::last_os_error()))

--- a/src/service.rs
+++ b/src/service.rs
@@ -13,6 +13,7 @@ use windows_sys::{
     core::GUID,
     Win32::{
         Foundation::{ERROR_SERVICE_SPECIFIC_ERROR, NO_ERROR},
+        Storage::FileSystem,
         System::{Power, RemoteDesktop, Services, SystemServices, WindowsProgramming::INFINITE},
         UI::WindowsAndMessaging,
     },
@@ -67,7 +68,7 @@ bitflags::bitflags! {
         const INTERROGATE = Services::SERVICE_INTERROGATE;
 
         /// Can delete the service
-        const DELETE = SystemServices::DELETE;
+        const DELETE = FileSystem::DELETE;
 
         /// Can query the services configuration
         const QUERY_CONFIG = Services::SERVICE_QUERY_CONFIG;
@@ -1382,7 +1383,7 @@ impl Service {
             .map(|s| WideCString::from_os_str(s).map_err(|_| Error::StartArgumentHasNulByte))
             .collect::<crate::Result<Vec<WideCString>>>()?;
 
-        let raw_service_arguments: Vec<*mut u16> = wide_service_arguments
+        let raw_service_arguments: Vec<_> = wide_service_arguments
             .iter()
             .map(|s| s.as_ptr() as _)
             .collect();

--- a/src/service.rs
+++ b/src/service.rs
@@ -1801,7 +1801,7 @@ pub(crate) fn to_wide(
 /// Escapes a given string, but also checks it does not contain any null bytes
 fn escape_wide(s: impl AsRef<OsStr>) -> ::std::result::Result<WideString, ContainsNul<u16>> {
     let escaped = shell_escape::escape(Cow::Borrowed(s.as_ref()));
-    let wide = WideCString::from_os_str(&escaped)?;
+    let wide = WideCString::from_os_str(escaped)?;
     Ok(wide.to_ustring())
 }
 

--- a/src/service_control_handler.rs
+++ b/src/service_control_handler.rs
@@ -148,12 +148,7 @@ where
 
     match unsafe { ServiceControl::from_raw(control, event_type, event_data) } {
         Ok(service_control) => {
-            let need_release = match service_control {
-                ServiceControl::Stop | ServiceControl::Shutdown | ServiceControl::Preshutdown => {
-                    true
-                }
-                _ => false,
-            };
+            let need_release = matches!(service_control, ServiceControl::Stop | ServiceControl::Shutdown | ServiceControl::Preshutdown);
 
             let return_code = event_handler(service_control).to_raw();
 

--- a/src/service_control_handler.rs
+++ b/src/service_control_handler.rs
@@ -148,7 +148,10 @@ where
 
     match unsafe { ServiceControl::from_raw(control, event_type, event_data) } {
         Ok(service_control) => {
-            let need_release = matches!(service_control, ServiceControl::Stop | ServiceControl::Shutdown | ServiceControl::Preshutdown);
+            let need_release = matches!(
+                service_control,
+                ServiceControl::Stop | ServiceControl::Shutdown | ServiceControl::Preshutdown
+            );
 
             let return_code = event_handler(service_control).to_raw();
 

--- a/src/service_manager.rs
+++ b/src/service_manager.rs
@@ -100,8 +100,8 @@ impl ServiceManager {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use std::ffi::OsString;
-    /// use std::path::PathBuf;
+    /// use std::ffi::OsStr;
+    /// use std::path::Path;
     /// use windows_service::service::{
     ///     ServiceAccess, ServiceErrorControl, ServiceInfo, ServiceStartType, ServiceType,
     /// };
@@ -111,15 +111,15 @@ impl ServiceManager {
     ///     let manager =
     ///         ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CREATE_SERVICE)?;
     ///
-    ///     let my_service_info = ServiceInfo {
-    ///         name: OsString::from("my_service"),
-    ///         display_name: OsString::from("My service"),
+    ///     let my_service_info: ServiceInfo<&OsStr> = ServiceInfo {
+    ///         name: OsStr::new("my_service"),
+    ///         display_name: OsStr::new("My service"),
     ///         service_type: ServiceType::OWN_PROCESS,
     ///         start_type: ServiceStartType::OnDemand,
     ///         error_control: ServiceErrorControl::Normal,
-    ///         executable_path: PathBuf::from(r"C:\path\to\my\service.exe"),
-    ///         launch_arguments: vec![],
-    ///         dependencies: vec![],
+    ///         executable_path: Path::new(r"C:\path\to\my\service.exe"),
+    ///         launch_arguments: &[],
+    ///         dependencies: &[],
     ///         account_name: None, // run as System
     ///         account_password: None,
     ///     };
@@ -128,9 +128,9 @@ impl ServiceManager {
     ///     Ok(())
     /// }
     /// ```
-    pub fn create_service(
+    pub fn create_service<T: AsRef<OsStr>>(
         &self,
-        service_info: &ServiceInfo,
+        service_info: &ServiceInfo<T>,
         service_access: ServiceAccess,
     ) -> Result<Service> {
         let raw_info = RawServiceInfo::new(service_info)?;


### PR DESCRIPTION
## Bug fixes and refactors
### 1. Breaking: change `Service.delete` to borrow rather than consume `self`
The underlying win32 API call merely marks the service for deletion. It can be called even if the service is not stopped and will not invalidate the caller's open handle to it. Making the function not consuming `self` allows the caller to decide when to close the handle. Docs and examples are updated to reflect this change.
### 2. Refactor `double_nul_terminated` implementation
- Rename `from_vec` to `from_slice` since it takes a slice, not a `Vec`.
- Allocate `WideString` in `from_slice` with pre-calculated capacity.
- Add unit tests for `from_slice`.
### 3. Bump `windows-sys` to `0.45`
An additional feature `Win32_Storage_FileSystem` is pulled in just for the flag `FileSystem::DELETE`. This does not feel right, but hard-coding it ourselves feels worse.

## New Features
### 4. Add public method `Service.set_delayed_auto_start`
This function configures if an auto-start service should be delayed.
### 5. Add public method `Error.is_os_error`
This function checks if an error from win32 API call matches a specific OS error code.

## Public API changes
These three are more opinionated public API changes based on my own needs, If these do not feel right for you, I'll revert them.
### 6. Breaking: remove `ServiceDependency`
- It does not seem to do anything useful. The '+' prefix of a group dependency has to be passed to the win32 API. An `OsString` will suffice here since it is up to users to distinguish between service and group dependencies.
- If users want to check if a dependency is a group, they can simply check if the `OsString` starts with '+'.
### 7. Breaking: change `ServiceInfo` to a borrowed type
This change allows the caller to retain individual ownership of the fields of `ServiceInfo` without having to clone them.
### 8. Possibly breaking: replace `err-derive` with `thiserror`
  - Both crates derive `std::error::Error` for an enum with slightly different syntax. For this crate it is a drop-in replacement and unlikely to break anything.
  - `thiserror` has some extra features and are better maintained.
  - Because `thiserror` is vastly more popular (76,032,688 total downloads and 8400 dependent crates compared to `err-derive`'s 2,175,409 and 71), it is very likely that many users of this crate already depend on `thiserror` and will have less dependencies if  this switch is made. (In fact, crates.io shows that this crate is the most downloaded dependent of `err-derive`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/87)
<!-- Reviewable:end -->
