### PR TITLE
Add `Service.set_delayed_auto_start`

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -1692,6 +1692,26 @@ impl Service {
         }
     }
 
+    /// Set if an auto-start service should be delayed.
+    ///
+    /// If true, the service is started after other auto-start services are started plus a short delay.
+    /// Otherwise, the service is started during system boot. The default is false. This setting is
+    /// ignored unless the service is an auto-start service.
+    ///
+    /// Required permission: [`ServiceAccess::CHANGE_CONFIG`].
+    pub fn set_delayed_auto_start(&self, delayed: bool) -> crate::Result<()> {
+        let mut delayed = Services::SERVICE_DELAYED_AUTO_START_INFO {
+            fDelayedAutostart: delayed as i32,
+        };
+        unsafe {
+            self.change_config2(
+                Services::SERVICE_CONFIG_DELAYED_AUTO_START_INFO,
+                &mut delayed,
+            )
+            .map_err(Error::Winapi)
+        }
+    }
+
     /// Private helper to send the control commands to the system.
     fn send_control_command(&self, command: ServiceControl) -> crate::Result<ServiceStatus> {
         let mut raw_status = unsafe { mem::zeroed::<Services::SERVICE_STATUS>() };


### PR DESCRIPTION
This function wraps the Win32 API which configures if an auto-start service should be delayed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/88)
<!-- Reviewable:end -->
