### PR TITLE
Add `Error.is_os_error`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,12 +269,10 @@ impl Error {
     ///
     /// [official docs]: https://learn.microsoft.com/en-us/windows/win32/api/winsvc/#functions
     pub fn is_os_error(&self, error_code: i32) -> bool {
-        if let Self::Winapi(e) = self {
-            if e.raw_os_error() == Some(error_code) {
-                return true;
-            }
+        match self {
+            Self::Winapi(e) => e.raw_os_error() == Some(error_code),
+            _ => false,
         }
-        false
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,6 +258,26 @@ pub enum Error {
     Winapi(#[error(source)] std::io::Error),
 }
 
+impl Error {
+    /// Return if an error from win32 API call matches the specific OS error code.
+    ///
+    /// To find the names of OS error codes that a specific win32 API call may return,
+    /// browse the [official docs]. They are also defined in `windows_sys` crate.
+    ///
+    /// For example, [`windows_sys::Win32::Foundation::ERROR_SERVICE_DOES_NOT_EXIST`] may
+    /// be returned by [`service_manager::ServiceManager::open_service`].
+    ///
+    /// [official docs]: https://learn.microsoft.com/en-us/windows/win32/api/winsvc/#functions
+    pub fn is_os_error(&self, error_code: i32) -> bool {
+        if let Self::Winapi(e) = self {
+            if e.raw_os_error() == Some(error_code) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
 mod sc_handle;
 pub mod service;
 pub mod service_control_handler;


### PR DESCRIPTION
This function checks if an error from win32 API call matches a specific OS error code. This makes it easier for users to check specific API errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/89)
<!-- Reviewable:end -->
