### PR TITLE
Breaking: change `Service.delete` to borrow rather than consume `self`

### DIFF
--- a/examples/uninstall_service.rs
+++ b/examples/uninstall_service.rs
@@ -1,10 +1,10 @@
 #[cfg(windows)]
 fn main() -> windows_service::Result<()> {
-    use std::{thread, time::Duration};
     use windows_service::{
         service::{ServiceAccess, ServiceState},
         service_manager::{ServiceManager, ServiceManagerAccess},
     };
+    use windows_sys::Win32::Foundation::ERROR_SERVICE_DOES_NOT_EXIST;
 
     let manager_access = ServiceManagerAccess::CONNECT;
     let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
@@ -12,14 +12,26 @@ fn main() -> windows_service::Result<()> {
     let service_access = ServiceAccess::QUERY_STATUS | ServiceAccess::STOP | ServiceAccess::DELETE;
     let service = service_manager.open_service("ping_service", service_access)?;
 
-    let service_status = service.query_status()?;
-    if service_status.current_state != ServiceState::Stopped {
+    // The service will be marked for deletion as long as this function call succeeds.
+    // However, it will not be deleted from the database until it is stopped and all open handles to it are closed.
+    service.delete()?;
+    // Our handle to it is not closed yet. So we can still query it.
+    if service.query_status()?.current_state != ServiceState::Stopped {
+        // If the service cannot be stopped, it will be deleted when the system restarts.
         service.stop()?;
-        // Wait for service to stop
-        thread::sleep(Duration::from_secs(1));
+    }
+    // Explicitly close our open handle to the service. This is automatically called when `service` goes out of scope.
+    drop(service);
+
+    // Check if the service is deleted.
+    if let Err(windows_service::Error::Winapi(e)) =
+        service_manager.open_service("ping_service", ServiceAccess::QUERY_STATUS)
+    {
+        if e.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST as i32) {
+            println!("ping_service is deleted.");
+        }
     }
 
-    service.delete()?;
     Ok(())
 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -1455,8 +1455,13 @@ impl Service {
         }
     }
 
-    /// Delete the service from system registry.
-    pub fn delete(self) -> crate::Result<()> {
+    /// Mark the service for deletion from the service control manager database.
+    ///
+    /// The database entry is not removed until all open handles to the service have been closed
+    /// and the service is stopped. If the service is not or cannot be stopped, the database entry
+    /// is removed when the system is restarted. This function will return an error if the service
+    /// has already been marked for deletion.
+    pub fn delete(&self) -> crate::Result<()> {
         let success = unsafe { Services::DeleteService(self.service_handle.raw_handle()) };
         if success == 0 {
             Err(Error::Winapi(io::Error::last_os_error()))


### PR DESCRIPTION
The underlying win32 API call merely marks the service for deletion. It can be called even if the service is not stopped and will not invalidate the caller's open handle to it. Making the function not consuming self allows the caller to decide when to close the handle. Docs and examples are updated to show the correct behavior of this API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/90)
<!-- Reviewable:end -->
