### PR TITLE
Refactor `double_nul_terminated`

### DIFF
--- a/src/double_nul_terminated.rs
+++ b/src/double_nul_terminated.rs
@@ -21,9 +21,9 @@ pub fn from_slice(source: &[impl AsRef<OsStr>]) -> Result<Option<WideString>, Co
         for s in source {
             let checked_str = WideCString::from_os_str(s)?;
             wide.push_slice(checked_str);
-            wide.push_slice(&[0]);
+            wide.push_slice([0]);
         }
-        wide.push_slice(&[0]);
+        wide.push_slice([0]);
         Ok(Some(wide))
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -454,7 +454,7 @@ impl RawServiceInfo {
             .iter()
             .map(|dependency| dependency.to_system_identifier())
             .collect();
-        let joined_dependencies = double_nul_terminated::from_vec(&dependency_identifiers)
+        let joined_dependencies = double_nul_terminated::from_slice(&dependency_identifiers)
             .map_err(|_| Error::DependencyHasNulByte)?;
 
         Ok(Self {

--- a/src/service.rs
+++ b/src/service.rs
@@ -1802,7 +1802,7 @@ pub(crate) fn to_wide(
 /// Escapes a given string, but also checks it does not contain any null bytes
 fn escape_wide(s: impl AsRef<OsStr>) -> ::std::result::Result<WideString, ContainsNul<u16>> {
     let escaped = shell_escape::escape(Cow::Borrowed(s.as_ref()));
-    let wide = WideCString::from_os_str(&escaped)?;
+    let wide = WideCString::from_os_str(escaped)?;
     Ok(wide.to_ustring())
 }
 

--- a/src/service_control_handler.rs
+++ b/src/service_control_handler.rs
@@ -53,7 +53,7 @@ unsafe impl Sync for ServiceStatusHandle {}
 /// <https://msdn.microsoft.com/en-us/library/windows/desktop/ms683241(v=vs.85).aspx>
 #[derive(Debug)]
 pub enum ServiceControlHandlerResult {
-    /// Either used to aknowledge the call or grant the permission in advanced events.
+    /// Either used to acknowledge the call or grant the permission in advanced events.
     NoError,
     /// The received event is not implemented.
     NotImplemented,

--- a/src/shell_escape.rs
+++ b/src/shell_escape.rs
@@ -13,7 +13,7 @@ mod utf16 {
     pub const VTAB: u16 = 0x000B; // '\v'
 }
 
-/// Loselessly escape shell arguments on Windows.
+/// Losslessly escape shell arguments on Windows.
 ///
 /// Inspired by https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/.
 /// Heavily based on https://github.com/sfackler/shell-escape


### PR DESCRIPTION
1. Rename `from_vec` to `from_slice` since it takes a slice, not a `Vec`.
2. Allocate `WideString` in `from_slice` with pre-calculated capacity.
3. Add unit tests for `from_slice`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/91)
<!-- Reviewable:end -->
