### PR TITLE
Minor adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Add support for delayed autostart in services. (See: `Service::set_delayed_auto_start`)
+- Add support for specifying a preshutdown timeout. (See: `Service::set_preshutdown_timeout`)
 
 ### Changed
 - Breaking: Consolidate `Error` type. Remove dependency on `err-derive`.

--- a/src/service.rs
+++ b/src/service.rs
@@ -1728,7 +1728,7 @@ impl Service {
     /// Required permission: [`ServiceAccess::CHANGE_CONFIG`].
     pub fn set_preshutdown_timeout(&self, timeout: Duration) -> crate::Result<()> {
         let mut timeout = Services::SERVICE_PRESHUTDOWN_INFO {
-            dwPreshutdownTimeout: timeout.as_millis() as u32,
+            dwPreshutdownTimeout: u32::try_from(timeout.as_millis()).expect("Too long timeout"),
         };
         unsafe {
             self.change_config2(Services::SERVICE_CONFIG_PRESHUTDOWN_INFO, &mut timeout)


### PR DESCRIPTION
- This PR adds additional message to panic error by using `Result::expect()` when converting `Duration` to `u32`.
- Update CHANGELOG with the recent addition of pre shutdown timeout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/98)
<!-- Reviewable:end -->
