### PR TITLE
deps: update to windows-sys 0.52.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bitflags = "2.3"
 widestring = "1"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.48.0"
+version = "0.52.0"
 features = [
     "Win32_Foundation",
     "Win32_Security",


### PR DESCRIPTION
`windows-sys` moved its MSRV to 1.56, which is less or equal to the one in this crate since the
edition for `windows-service` is 2021, so no impact there.

Could we have a release after this is merged ? ~~I don't see any `pub use` of `windows_sys::` stuff
so a point release should be enough.~~ `windows-sys` is part of the public API so it would need a breaking release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/109)
<!-- Reviewable:end -->
