### PR TITLE
Pin mingw version in workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,6 +35,9 @@ jobs:
         uses: egor-tensin/setup-mingw@v2
         with:
           platform: ${{ matrix.platform }}
+          # Pinning a working version of MinGW since we've issues with the action using newer
+          # versions
+          version: 12.2.0.03042023
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1.0.6


### PR DESCRIPTION
There's an issue with the `setup-mingw` action for newer versions of mingw: https://github.com/mullvad/windows-service-rs/actions/runs/6889525757/job/18745989633?pr=109

Let's use an older version of mingw until that has been fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/110)
<!-- Reviewable:end -->
