### PR TITLE
Implement new Service method to retrieve its SID type info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Breaking: Consolidate `Error` type. Remove dependency on `err-derive`.
-- Breaking: `Service::delete` does not consume `self` any longer. Make sure to `drop` a reference 
-  to `Service` manually if you plan to poll SCM synchronously to determine when the service is 
+- Breaking: `Service::delete` does not consume `self` any longer. Make sure to `drop` a reference
+  to `Service` manually if you plan to poll SCM synchronously to determine when the service is
   removed from system. (See `uninstall_service.rs` example)
 
 
@@ -41,8 +41,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.4.0] - 2021-08-12
 ### Changed
-- Breaking: `ServiceDependency::from_system_identifier()`, `ServiceManager::new()`, 
-  `ServiceManager::local_computer()`, `ServiceManager::remote_computer()` now take 
+- Breaking: `ServiceDependency::from_system_identifier()`, `ServiceManager::new()`,
+  `ServiceManager::local_computer()`, `ServiceManager::remote_computer()` now take
   `impl AsRef<OsStr>` arguments.
 - Upgrade err-derive dependency to 0.3.0
 - `ServiceStatusHandle` is now Sync.
@@ -64,9 +64,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add support for configuring the service SID info.
 - Add support for changing mandatory configuration settings on service.
-- Add support for service failure actions. (See: `ServiceFailureActions`, 
-  `Service::update_failure_actions`, `Service::get_failure_actions`, 
-  `Service::set_failure_actions_on_non_crash_failures`, 
+- Add support for service failure actions. (See: `ServiceFailureActions`,
+  `Service::update_failure_actions`, `Service::get_failure_actions`,
+  `Service::set_failure_actions_on_non_crash_failures`,
   `Service::get_failure_actions_on_non_crash_failures`)
 - Add support to pause and continue services. (See: `Service::pause` and `Service::resume`)
 - Use `QueryServiceStatusEx` when querying service status. Allows getting the process ID of a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   (See: `Service::notify` and `notify_service.rs` example)
 - Add support for `LidSwitchStateChange` in `PowerBroadcastSetting`.
   (See: `LidSwitchStateChange`)
+- Add function for obtaining service SID infos. (See: `Service::get_config_service_sid_info`).
 
 
 ## [0.6.0] - 2023-03-07

--- a/src/service.rs
+++ b/src/service.rs
@@ -1644,6 +1644,21 @@ impl Service {
         Ok(raw_failure_actions_flag.fFailureActionsOnNonCrashFailures != 0)
     }
 
+    /// Query the system for the service's SID type information.
+    ///
+    /// The service must be open with the [`ServiceAccess::QUERY_CONFIG`]
+    /// access permission prior to calling this method.
+    pub fn get_config_service_sid_info(&self) -> crate::Result<ServiceSidType> {
+        let mut data = vec![0u8; u32::BITS as usize / 8];
+
+        // SAFETY: The structure we get back is `SERVICE_SID_INFO`. It has a
+        // single member that specifies the new SID type as a `u32`, and as
+        // such, we can get away with not explicitly creating a structure and
+        // instead re-using `ServiceSidType` that is `repr(u32)`.
+        unsafe { self.query_config2(Services::SERVICE_CONFIG_SERVICE_SID_INFO, &mut data) }
+            .map_err(Error::Winapi)
+    }
+
     pub fn set_config_service_sid_info(
         &self,
         mut service_sid_type: ServiceSidType,

--- a/src/service.rs
+++ b/src/service.rs
@@ -1659,11 +1659,16 @@ impl Service {
             .map_err(Error::Winapi)
     }
 
+    /// Require the system to set the service's SID type information to the
+    /// provided value.
+    ///
+    /// The service must be open with the [`ServiceAccess::CHANGE_CONFIG`]
+    /// access permission prior to calling this method.
     pub fn set_config_service_sid_info(
         &self,
         mut service_sid_type: ServiceSidType,
     ) -> crate::Result<()> {
-        // The structure we need to pass in is `SERVICE_SID_INFO`.
+        // SAFETY: The structure we need to pass in is `SERVICE_SID_INFO`.
         // It has a single member that specifies the new SID type, and as such,
         // we can get away with not explicitly creating a structure in Rust.
         unsafe {


### PR DESCRIPTION
Dear maintainers,

The `Service` struct supports modifying the underlying system resource's SID type information through the `Service::set_config_service_sid_info` method. However, there is currently no way to easily retrieve the value from the service manager, for example to check if a call to `set_config_service_sid_info` actually worked.

This PR therefore adds a new small `Service::get_config_service_sid_info` method that does just that. Also, some other minor bonus changes are included.

Cheers,
Paul.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/112)
<!-- Reviewable:end -->
