### PR TITLE
Add `SystemStart` and `BootStart` start types

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -93,6 +93,10 @@ pub enum ServiceStartType {
     OnDemand = Services::SERVICE_DEMAND_START,
     /// Disabled service
     Disabled = Services::SERVICE_DISABLED,
+    /// Start on system startup
+    SystemStart = Services::SERVICE_SYSTEM_START,
+    /// Start on OS boot
+    BootStart = Services::SERVICE_BOOT_START,
 }
 
 impl ServiceStartType {
@@ -105,6 +109,8 @@ impl ServiceStartType {
             x if x == ServiceStartType::AutoStart.to_raw() => Ok(ServiceStartType::AutoStart),
             x if x == ServiceStartType::OnDemand.to_raw() => Ok(ServiceStartType::OnDemand),
             x if x == ServiceStartType::Disabled.to_raw() => Ok(ServiceStartType::Disabled),
+            x if x == ServiceStartType::SystemStart.to_raw() => Ok(ServiceStartType::SystemStart),
+            x if x == ServiceStartType::BootStart.to_raw() => Ok(ServiceStartType::BootStart),
             _ => Err(ParseRawError::InvalidInteger(raw)),
         }
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -86,6 +86,7 @@ bitflags::bitflags! {
 /// Enum describing the start options for windows services.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u32)]
+#[non_exhaustive]
 pub enum ServiceStartType {
     /// Autostart on system startup
     AutoStart = Services::SERVICE_AUTO_START,

--- a/src/service.rs
+++ b/src/service.rs
@@ -86,7 +86,6 @@ bitflags::bitflags! {
 /// Enum describing the start options for windows services.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u32)]
-#[non_exhaustive]
 pub enum ServiceStartType {
     /// Autostart on system startup
     AutoStart = Services::SERVICE_AUTO_START,

--- a/src/service.rs
+++ b/src/service.rs
@@ -93,9 +93,11 @@ pub enum ServiceStartType {
     OnDemand = Services::SERVICE_DEMAND_START,
     /// Disabled service
     Disabled = Services::SERVICE_DISABLED,
-    /// Start on system startup
+    /// Driver start on system startup.
+    /// This start type is only applicable to driver services.
     SystemStart = Services::SERVICE_SYSTEM_START,
-    /// Start on OS boot
+    /// Driver start on OS boot.
+    /// This start type is only applicable to driver services.
     BootStart = Services::SERVICE_BOOT_START,
 }
 


### PR DESCRIPTION
Added `SystemStart` (`SERVICE_SYSTEM_START`) and `BootStart` (`SERVICE_BOOT_START`) start types.
This change has been tested locally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/113)
<!-- Reviewable:end -->
