### PR TITLE
Add some missing flags and expose service handle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-service"
-version = "0.6.0"
+version = "0.6.1"
 description = "A crate that provides facilities for management and implementation of windows services"
 readme = "README.md"
 authors = ["Mullvad VPN"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-service"
-version = "0.6.1"
+version = "0.6.2"
 description = "A crate that provides facilities for management and implementation of windows services"
 readme = "README.md"
 authors = ["Mullvad VPN"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-service"
-version = "0.6.2"
+version = "0.6.0"
 description = "A crate that provides facilities for management and implementation of windows services"
 readme = "README.md"
 authors = ["Mullvad VPN"]

--- a/src/service.rs
+++ b/src/service.rs
@@ -1442,6 +1442,11 @@ impl Service {
         Service { service_handle }
     }
 
+    /// Provides access to the underlying system service handle
+    pub fn raw_handle(&self) -> Security::SC_HANDLE {
+        self.service_handle.raw_handle()
+    }
+
     /// Start the service.
     ///
     /// # Example
@@ -1845,10 +1850,6 @@ impl Service {
             self.change_config2(Services::SERVICE_CONFIG_PRESHUTDOWN_INFO, &mut timeout)
                 .map_err(Error::Winapi)
         }
-    }
-
-    pub fn raw_service_handle(&self) -> Security::SC_HANDLE {
-        self.service_handle.raw_handle()
     }
 
     /// Private helper to send the control commands to the system.

--- a/src/service.rs
+++ b/src/service.rs
@@ -14,6 +14,7 @@ use windows_sys::{
     Win32::{
         Foundation::{ERROR_SERVICE_SPECIFIC_ERROR, NO_ERROR},
         Storage::FileSystem,
+        Security,
         System::{Power, RemoteDesktop, Services, SystemServices, Threading::INFINITE},
         UI::WindowsAndMessaging,
     },
@@ -1841,6 +1842,10 @@ impl Service {
             self.change_config2(Services::SERVICE_CONFIG_PRESHUTDOWN_INFO, &mut timeout)
                 .map_err(Error::Winapi)
         }
+    }
+
+    pub fn raw_service_handle(&self) -> Security::SC_HANDLE {
+        self.service_handle.raw_handle()
     }
 
     /// Private helper to send the control commands to the system.

--- a/src/service.rs
+++ b/src/service.rs
@@ -81,6 +81,9 @@ bitflags::bitflags! {
 
         /// Can use user-defined control codes
         const USER_DEFINED_CONTROL = Services::SERVICE_USER_DEFINED_CONTROL;
+
+        /// Full access to the service object
+        const ALL_ACCESS = Services::SERVICE_ALL_ACCESS;
     }
 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -13,8 +13,8 @@ use windows_sys::{
     core::GUID,
     Win32::{
         Foundation::{ERROR_SERVICE_SPECIFIC_ERROR, NO_ERROR},
-        Storage::FileSystem,
         Security,
+        Storage::FileSystem,
         System::{Power, RemoteDesktop, Services, SystemServices, Threading::INFINITE},
         UI::WindowsAndMessaging,
     },

--- a/src/service_manager.rs
+++ b/src/service_manager.rs
@@ -22,6 +22,7 @@ bitflags::bitflags! {
         /// Can enumerate services or receive notifications.
         const ENUMERATE_SERVICE = Services::SC_MANAGER_ENUMERATE_SERVICE;
 
+        /// Includes all possible access rights.
         const ALL_ACCESS = Services::SC_MANAGER_ALL_ACCESS;
     }
 }

--- a/src/service_manager.rs
+++ b/src/service_manager.rs
@@ -21,6 +21,8 @@ bitflags::bitflags! {
 
         /// Can enumerate services or receive notifications.
         const ENUMERATE_SERVICE = Services::SC_MANAGER_ENUMERATE_SERVICE;
+
+        const ALL_ACCESS = Services::SC_MANAGER_ALL_ACCESS;
     }
 }
 


### PR DESCRIPTION
This adds some of the ALL_ACCESS flags + exposes the raw service handle. I'm personally using this for [SetServiceObjectSecurity](https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-setserviceobjectsecurity). 

One could expose a more Rust-like `set_service_object_security()` call, though it could become fairly complex. I'm hesitant to try to do that right away before the library is based off of the official Windows crates.

Thoughts?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/115)
<!-- Reviewable:end -->
