### PR TITLE
add the MSRV to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ categories = ["api-bindings", "os::windows-apis"]
 repository = "https://github.com/mullvad/windows-service-rs"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.58.0"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"


### PR DESCRIPTION
specifying the MSRV in cargo.toml allows cargo to use it when resolving dependencies. Also clippy parses this value and doesn't suggest syntax introduced after the MSRV

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/117)
<!-- Reviewable:end -->
