### PR TITLE
Add WRITE_DAC to ServiceAccess enum in service.rs

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use std::{io, mem};
 
 use widestring::{error::ContainsNul, WideCStr, WideCString, WideString};
+use windows_sys::Win32::Storage::FileSystem::WRITE_DAC;
 use windows_sys::{
     core::GUID,
     Win32::{
@@ -80,6 +81,9 @@ bitflags::bitflags! {
 
         /// Can use user-defined control codes
         const USER_DEFINED_CONTROL = Services::SERVICE_USER_DEFINED_CONTROL;
+
+        /// Can update the DAC, required for SetServiceObjectSecurity()
+        const WRITE_DAC = WRITE_DAC;
 
         /// Full access to the service object
         const ALL_ACCESS = Services::SERVICE_ALL_ACCESS;


### PR DESCRIPTION
Need this for a call to change a DACL where admins only have WRITE_DAC access.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/121)
<!-- Reviewable:end -->
