### PR TITLE
Mark lots of enums `#[non_exhaustive]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   (See: `LidSwitchStateChange`)
 - Add function for obtaining service SID infos. (See: `Service::get_config_service_sid_info`).
 
+### Changed
+- Breaking: Make a bunch of enums `#[non_exhaustive]`: `Error`, `PowerBroadcastSetting`,
+  `PowerEventParam`, `SessionChangeReason` and `ServiceControl`.
+
 
 ## [0.6.0] - 2023-03-07
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,7 @@
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// Kernel drivers do not support launch arguments
     LaunchArgumentsNotSupported,

--- a/src/service.rs
+++ b/src/service.rs
@@ -899,6 +899,7 @@ impl PowerBroadcastSetting {
 
 /// Enum describing the PowerEvent event
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum PowerEventParam {
     PowerStatusChange,
     ResumeAutomatic,

--- a/src/service.rs
+++ b/src/service.rs
@@ -809,6 +809,7 @@ impl LidSwitchStateChange {
 /// Please refer to MSDN for more info about the data members:
 /// <https://docs.microsoft.com/en-us/windows/win32/power/power-setting-guid>
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum PowerBroadcastSetting {
     AcdcPowerSource(PowerSource),
     BatteryPercentageRemaining(u32),

--- a/src/service.rs
+++ b/src/service.rs
@@ -1081,6 +1081,7 @@ impl UserEventCode {
 
 /// Enum describing the service control operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum ServiceControl {
     Continue,
     Interrogate,


### PR DESCRIPTION
For the upcoming `0.7.0` release we have a lot of breaking changes due to adding variants to enums. Lots of these enums are probably still not exhaustive. To mitigate having to make breaking changes for small stuff in the future, I mark them as `#[non_exhaustive]`. If you think any of these actually are fully exhaustive now, and/or if you think an addition to one of them actually should be a breaking change, then please give that as feedback.

I want this merged before the `0.7.0` release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/124)
<!-- Reviewable:end -->
