### PR TITLE
Prepare to release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+
+## [0.7.0] - 2024-04-12
 ### Added
 - Breaking: Add support for user-defined control codes in services.
   (See: `Service::notify` and `notify_service.rs` example). This is breaking since

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   (See: `Service::notify` and `notify_service.rs` example)
 - Add support for `LidSwitchStateChange` in `PowerBroadcastSetting`.
   (See: `LidSwitchStateChange`)
+- Add support for `SERVICE_SYSTEM_START` and `SERVICE_BOOT_START` in service start type
 - Add function for obtaining service SID infos. (See: `Service::get_config_service_sid_info`).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Add support for user-defined control codes in services.
-  (See: `Service::notify` and `notify_service.rs` example)
-- Add support for `LidSwitchStateChange` in `PowerBroadcastSetting`.
-  (See: `LidSwitchStateChange`)
-- Add support for `SERVICE_SYSTEM_START` and `SERVICE_BOOT_START` in service start type
+- Breaking: Add support for user-defined control codes in services.
+  (See: `Service::notify` and `notify_service.rs` example). This is breaking since
+  the `ServiceControl` enum was exhaustive in version 0.6.0.
+- Breaking: Add support for `LidSwitchStateChange` in `PowerBroadcastSetting`. This is breaking
+  since `PowerBroadcastSetting` was an exhaustive enum in version 0.6.0.
+- Breaking: Add support for `SERVICE_SYSTEM_START` and `SERVICE_BOOT_START` in service
+  start type. This is breaking since the `ServiceStartType` enum is exhaustive.
 - Add function for obtaining service SID infos. (See: `Service::get_config_service_sid_info`).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Breaking: Make a bunch of enums `#[non_exhaustive]`: `Error`, `PowerBroadcastSetting`,
-  `PowerEventParam`, `SessionChangeReason` and `ServiceControl`.
+  `PowerEventParam` and `ServiceControl`.
 - Breaking: Upgrade `windows-sys` dependency to 0.52
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Breaking: Make a bunch of enums `#[non_exhaustive]`: `Error`, `PowerBroadcastSetting`,
   `PowerEventParam`, `SessionChangeReason` and `ServiceControl`.
+- Breaking: Upgrade `windows-sys` dependency to 0.52
 
 
 ## [0.6.0] - 2023-03-07

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-service"
-version = "0.6.0"
+version = "0.7.0"
 description = "A crate that provides facilities for management and implementation of windows services"
 readme = "README.md"
 authors = ["Mullvad VPN"]


### PR DESCRIPTION
Lots of stuff has happened and a full year has passed since 0.6.0. It's about time we get with the times. Here I prepare for releasing 0.7.0. It's a breaking release because we upgrade `windows-sys`

I want #124 merged before we go ahead with this release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/125)
<!-- Reviewable:end -->
