### PR TITLE
Display winapi errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,14 +209,14 @@ impl std::fmt::Display for Error {
             Self::LaunchArgumentsNotSupported => {
                 write!(f, "kernel drivers do not support launch arguments")
             }
-            Self::ParseValue(name, _) => write!(f, "invalid {} value", name),
+            Self::ParseValue(name, e) => write!(f, "invalid {} value. Err: {} ", name, e),
             Self::ArgumentHasNulByte(name) => write!(f, "{} contains a nul byte", name),
             Self::ArgumentArrayElementHasNulByte(name, index) => write!(
                 f,
                 "{} contains a nul byte in element at {} index",
                 name, index
             ),
-            Self::Winapi(_) => write!(f, "IO error in winapi call"),
+            Self::Winapi(e) => write!(f, "IO error in winapi call: {}", e),
         }
     }
 }


### PR DESCRIPTION
If the WinAPI connection fails, we have no information about what went wrong. The purpose of the PR is only to add WinAPI error information to the error message

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/134)
<!-- Reviewable:end -->
