### PR TITLE
Bump version to 0.8.0 and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Upgrade `windows-sys` dependency to 0.59 and bump the MSRV to 1.60.0
+
+
+## [0.8.0] - 2025-02-19
+### Added
+- Add missing ServiceAccess flags `READ_CONTROL`, `WRITE_DAC` and `WRITE_OWNER`. 
+
+### Changed
+- Upgrade `windows-sys` dependency to 0.59 and bump the MSRV to 1.60.0.
 
 
 ## [0.7.0] - 2024-04-12

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-service"
-version = "0.7.0"
+version = "0.8.0"
 description = "A crate that provides facilities for management and implementation of windows services"
 readme = "README.md"
 authors = ["Mullvad VPN"]


### PR DESCRIPTION
Fixes #135 

Long time since we released. I guess it could be nice to get the extra access control flags out, and the bump to latest `windows-sys` (that has been out for 7 months now)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/136)
<!-- Reviewable:end -->
