### PR TITLE
Add `Service.set_launch_protected, get_launch_protected`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.8.0] - 2025-02-19
 ### Added
 - Add missing ServiceAccess flags `READ_CONTROL`, `WRITE_DAC` and `WRITE_OWNER`. 
+- Add support for protected services (See: `ServiceLaunchProtected`).
 
 ### Changed
 - Upgrade `windows-sys` dependency to 0.59 and bump the MSRV to 1.60.0.

--- a/src/service.rs
+++ b/src/service.rs
@@ -366,31 +366,34 @@ impl ServiceFailureActions {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u32)]
 pub enum ServiceLaunchProtected {
+    /// No launch protection. The service can be modified or replaced without restriction.
     None = Services::SERVICE_LAUNCH_PROTECTED_NONE,
+
+    /// Launch protection for Windows components.
     Windows = Services::SERVICE_LAUNCH_PROTECTED_WINDOWS,
+
+    /// A lighter version of Windows launch protection.
     WindowsLight = Services::SERVICE_LAUNCH_PROTECTED_WINDOWS_LIGHT,
+
+    /// Launch protection used by antimalware (ELAM) services.
     AntimalwareLight = Services::SERVICE_LAUNCH_PROTECTED_ANTIMALWARE_LIGHT,
 }
-impl ServiceLaunchProtected {
-    pub fn to_raw(&self) -> u32 {
-        *self as u32
-    }
+impl TryFrom<u32> for ServiceLaunchProtected {
+    type Error = Error;
 
-    pub fn from_raw(raw: u32) -> crate::Result<ServiceLaunchProtected> {
-        match raw {
-            x if x == ServiceLaunchProtected::None.to_raw() => Ok(ServiceLaunchProtected::None),
-            x if x == ServiceLaunchProtected::Windows.to_raw() => {
-                Ok(ServiceLaunchProtected::Windows)
-            }
-            x if x == ServiceLaunchProtected::WindowsLight.to_raw() => {
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            Services::SERVICE_LAUNCH_PROTECTED_NONE => Ok(ServiceLaunchProtected::None),
+            Services::SERVICE_LAUNCH_PROTECTED_WINDOWS => Ok(ServiceLaunchProtected::Windows),
+            Services::SERVICE_LAUNCH_PROTECTED_WINDOWS_LIGHT => {
                 Ok(ServiceLaunchProtected::WindowsLight)
             }
-            x if x == ServiceLaunchProtected::AntimalwareLight.to_raw() => {
+            Services::SERVICE_LAUNCH_PROTECTED_ANTIMALWARE_LIGHT => {
                 Ok(ServiceLaunchProtected::AntimalwareLight)
             }
             _ => Err(Error::ParseValue(
                 "Invalid launch protection value",
-                ParseRawError::InvalidInteger(raw),
+                ParseRawError::InvalidInteger(value),
             )),
         }
     }
@@ -1846,7 +1849,7 @@ impl Service {
     pub fn set_launch_protected(&self, protection: ServiceLaunchProtected) -> crate::Result<()> {
         let mut launch_protected =
             unsafe { mem::zeroed::<Services::SERVICE_LAUNCH_PROTECTED_INFO>() };
-        launch_protected.dwLaunchProtected = protection.to_raw();
+        launch_protected.dwLaunchProtected = protection as u32;
         unsafe {
             self.change_config2(
                 Services::SERVICE_CONFIG_LAUNCH_PROTECTED,
@@ -1855,15 +1858,16 @@ impl Service {
             .map_err(Error::Winapi)
         }
     }
+    
     /// Get service launch protection.
     /// This is a security feature that allows the service to run in a more secure environment.
     pub fn get_launch_protected(&self) -> crate::Result<ServiceLaunchProtected> {
-        let mut data = vec![0u8; std::mem::size_of::<Services::SERVICE_LAUNCH_PROTECTED_INFO>()];
+        let mut data = [0u8; std::mem::size_of::<Services::SERVICE_LAUNCH_PROTECTED_INFO>()];
         unsafe {
             let raw_data: Services::SERVICE_LAUNCH_PROTECTED_INFO = self
                 .query_config2(Services::SERVICE_CONFIG_LAUNCH_PROTECTED, &mut data)
                 .map_err(Error::Winapi)?;
-            ServiceLaunchProtected::from_raw(raw_data.dwLaunchProtected)
+            raw_data.dwLaunchProtected.try_into()
         }
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -359,6 +359,42 @@ impl ServiceFailureActions {
     }
 }
 
+/// Enum describing the service launch protection options.
+///
+/// See <https://learn.microsoft.com/ko-kr/windows/win32/api/winsvc/ns-winsvc-service_launch_protected_info>
+/// for more information.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u32)]
+pub enum ServiceLaunchProtected {
+    None = Services::SERVICE_LAUNCH_PROTECTED_NONE,
+    Windows = Services::SERVICE_LAUNCH_PROTECTED_WINDOWS,
+    WindowsLight = Services::SERVICE_LAUNCH_PROTECTED_WINDOWS_LIGHT,
+    AntimalwareLight = Services::SERVICE_LAUNCH_PROTECTED_ANTIMALWARE_LIGHT,
+}
+impl ServiceLaunchProtected {
+    pub fn to_raw(&self) -> u32 {
+        *self as u32
+    }
+
+    pub fn from_raw(raw: u32) -> crate::Result<ServiceLaunchProtected> {
+        match raw {
+            x if x == ServiceLaunchProtected::None.to_raw() => Ok(ServiceLaunchProtected::None),
+            x if x == ServiceLaunchProtected::Windows.to_raw() => {
+                Ok(ServiceLaunchProtected::Windows)
+            }
+            x if x == ServiceLaunchProtected::WindowsLight.to_raw() => {
+                Ok(ServiceLaunchProtected::WindowsLight)
+            }
+            x if x == ServiceLaunchProtected::AntimalwareLight.to_raw() => {
+                Ok(ServiceLaunchProtected::AntimalwareLight)
+            }
+            _ => Err(Error::ParseValue(
+                "Invalid launch protection value",
+                ParseRawError::InvalidInteger(raw),
+            )),
+        }
+    }
+}
 /// A struct that describes the service.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ServiceInfo {
@@ -1799,6 +1835,35 @@ impl Service {
                 &mut raw_failure_actions,
             )
             .map_err(Error::Winapi)
+        }
+    }
+
+    /// Set service launch protection.
+    /// This is a security feature that allows the service to run in a more secure environment.
+    /// there is no example because you need EV Certification and ELAM Driver to test it.
+    /// Please refer to the official documentation for more information:
+    /// <https://learn.microsoft.com/en-us/windows/win32/services/protecting-anti-malware-services->
+    pub fn set_launch_protected(&self, protection: ServiceLaunchProtected) -> crate::Result<()> {
+        let mut launch_protected =
+            unsafe { mem::zeroed::<Services::SERVICE_LAUNCH_PROTECTED_INFO>() };
+        launch_protected.dwLaunchProtected = protection.to_raw();
+        unsafe {
+            self.change_config2(
+                Services::SERVICE_CONFIG_LAUNCH_PROTECTED,
+                &mut launch_protected,
+            )
+            .map_err(Error::Winapi)
+        }
+    }
+    /// Get service launch protection.
+    /// This is a security feature that allows the service to run in a more secure environment.
+    pub fn get_launch_protected(&self) -> crate::Result<ServiceLaunchProtected> {
+        let mut data = vec![0u8; std::mem::size_of::<Services::SERVICE_LAUNCH_PROTECTED_INFO>()];
+        unsafe {
+            let raw_data: Services::SERVICE_LAUNCH_PROTECTED_INFO = self
+                .query_config2(Services::SERVICE_CONFIG_LAUNCH_PROTECTED, &mut data)
+                .map_err(Error::Winapi)?;
+            ServiceLaunchProtected::from_raw(raw_data.dwLaunchProtected)
         }
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -362,6 +362,42 @@ impl ServiceFailureActions {
     }
 }
 
+/// Enum describing the service launch protection options.
+///
+/// See <https://learn.microsoft.com/ko-kr/windows/win32/api/winsvc/ns-winsvc-service_launch_protected_info>
+/// for more information.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u32)]
+pub enum ServiceLaunchProtected {
+    None = Services::SERVICE_LAUNCH_PROTECTED_NONE,
+    Windows = Services::SERVICE_LAUNCH_PROTECTED_WINDOWS,
+    WindowsLight = Services::SERVICE_LAUNCH_PROTECTED_WINDOWS_LIGHT,
+    AntimalwareLight = Services::SERVICE_LAUNCH_PROTECTED_ANTIMALWARE_LIGHT,
+}
+impl ServiceLaunchProtected {
+    pub fn to_raw(&self) -> u32 {
+        *self as u32
+    }
+
+    pub fn from_raw(raw: u32) -> crate::Result<ServiceLaunchProtected> {
+        match raw {
+            x if x == ServiceLaunchProtected::None.to_raw() => Ok(ServiceLaunchProtected::None),
+            x if x == ServiceLaunchProtected::Windows.to_raw() => {
+                Ok(ServiceLaunchProtected::Windows)
+            }
+            x if x == ServiceLaunchProtected::WindowsLight.to_raw() => {
+                Ok(ServiceLaunchProtected::WindowsLight)
+            }
+            x if x == ServiceLaunchProtected::AntimalwareLight.to_raw() => {
+                Ok(ServiceLaunchProtected::AntimalwareLight)
+            }
+            _ => Err(Error::ParseValue(
+                "Invalid launch protection value",
+                ParseRawError::InvalidInteger(raw),
+            )),
+        }
+    }
+}
 /// A struct that describes the service.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ServiceInfo {
@@ -1802,6 +1838,35 @@ impl Service {
                 &mut raw_failure_actions,
             )
             .map_err(Error::Winapi)
+        }
+    }
+
+    /// Set service launch protection.
+    /// This is a security feature that allows the service to run in a more secure environment.
+    /// there is no example because you need EV Certification and ELAM Driver to test it.
+    /// Please refer to the official documentation for more information:
+    /// <https://learn.microsoft.com/en-us/windows/win32/services/protecting-anti-malware-services->
+    pub fn set_launch_protected(&self, protection: ServiceLaunchProtected) -> crate::Result<()> {
+        let mut launch_protected =
+            unsafe { mem::zeroed::<Services::SERVICE_LAUNCH_PROTECTED_INFO>() };
+        launch_protected.dwLaunchProtected = protection.to_raw();
+        unsafe {
+            self.change_config2(
+                Services::SERVICE_CONFIG_LAUNCH_PROTECTED,
+                &mut launch_protected,
+            )
+            .map_err(Error::Winapi)
+        }
+    }
+    /// Get service launch protection.
+    /// This is a security feature that allows the service to run in a more secure environment.
+    pub fn get_launch_protected(&self) -> crate::Result<ServiceLaunchProtected> {
+        let mut data = vec![0u8; std::mem::size_of::<Services::SERVICE_LAUNCH_PROTECTED_INFO>()];
+        unsafe {
+            let raw_data: Services::SERVICE_LAUNCH_PROTECTED_INFO = self
+                .query_config2(Services::SERVICE_CONFIG_LAUNCH_PROTECTED, &mut data)
+                .map_err(Error::Winapi)?;
+            ServiceLaunchProtected::from_raw(raw_data.dwLaunchProtected)
         }
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -364,7 +364,7 @@ impl ServiceFailureActions {
 
 /// Enum describing the service launch protection options.
 ///
-/// See <https://learn.microsoft.com/ko-kr/windows/win32/api/winsvc/ns-winsvc-service_launch_protected_info>
+/// See <https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_launch_protected_info>
 /// for more information.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u32)]
@@ -381,6 +381,7 @@ pub enum ServiceLaunchProtected {
     /// Launch protection used by antimalware (ELAM) services.
     AntimalwareLight = Services::SERVICE_LAUNCH_PROTECTED_ANTIMALWARE_LIGHT,
 }
+
 impl TryFrom<u32> for ServiceLaunchProtected {
     type Error = Error;
 
@@ -401,6 +402,7 @@ impl TryFrom<u32> for ServiceLaunchProtected {
         }
     }
 }
+
 /// A struct that describes the service.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ServiceInfo {
@@ -1861,7 +1863,7 @@ impl Service {
             .map_err(Error::Winapi)
         }
     }
-    
+
     /// Get service launch protection.
     /// This is a security feature that allows the service to run in a more secure environment.
     pub fn get_launch_protected(&self) -> crate::Result<ServiceLaunchProtected> {

--- a/src/service.rs
+++ b/src/service.rs
@@ -369,31 +369,34 @@ impl ServiceFailureActions {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u32)]
 pub enum ServiceLaunchProtected {
+    /// No launch protection. The service can be modified or replaced without restriction.
     None = Services::SERVICE_LAUNCH_PROTECTED_NONE,
+
+    /// Launch protection for Windows components.
     Windows = Services::SERVICE_LAUNCH_PROTECTED_WINDOWS,
+
+    /// A lighter version of Windows launch protection.
     WindowsLight = Services::SERVICE_LAUNCH_PROTECTED_WINDOWS_LIGHT,
+
+    /// Launch protection used by antimalware (ELAM) services.
     AntimalwareLight = Services::SERVICE_LAUNCH_PROTECTED_ANTIMALWARE_LIGHT,
 }
-impl ServiceLaunchProtected {
-    pub fn to_raw(&self) -> u32 {
-        *self as u32
-    }
+impl TryFrom<u32> for ServiceLaunchProtected {
+    type Error = Error;
 
-    pub fn from_raw(raw: u32) -> crate::Result<ServiceLaunchProtected> {
-        match raw {
-            x if x == ServiceLaunchProtected::None.to_raw() => Ok(ServiceLaunchProtected::None),
-            x if x == ServiceLaunchProtected::Windows.to_raw() => {
-                Ok(ServiceLaunchProtected::Windows)
-            }
-            x if x == ServiceLaunchProtected::WindowsLight.to_raw() => {
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            Services::SERVICE_LAUNCH_PROTECTED_NONE => Ok(ServiceLaunchProtected::None),
+            Services::SERVICE_LAUNCH_PROTECTED_WINDOWS => Ok(ServiceLaunchProtected::Windows),
+            Services::SERVICE_LAUNCH_PROTECTED_WINDOWS_LIGHT => {
                 Ok(ServiceLaunchProtected::WindowsLight)
             }
-            x if x == ServiceLaunchProtected::AntimalwareLight.to_raw() => {
+            Services::SERVICE_LAUNCH_PROTECTED_ANTIMALWARE_LIGHT => {
                 Ok(ServiceLaunchProtected::AntimalwareLight)
             }
             _ => Err(Error::ParseValue(
                 "Invalid launch protection value",
-                ParseRawError::InvalidInteger(raw),
+                ParseRawError::InvalidInteger(value),
             )),
         }
     }
@@ -1849,7 +1852,7 @@ impl Service {
     pub fn set_launch_protected(&self, protection: ServiceLaunchProtected) -> crate::Result<()> {
         let mut launch_protected =
             unsafe { mem::zeroed::<Services::SERVICE_LAUNCH_PROTECTED_INFO>() };
-        launch_protected.dwLaunchProtected = protection.to_raw();
+        launch_protected.dwLaunchProtected = protection as u32;
         unsafe {
             self.change_config2(
                 Services::SERVICE_CONFIG_LAUNCH_PROTECTED,
@@ -1858,15 +1861,16 @@ impl Service {
             .map_err(Error::Winapi)
         }
     }
+    
     /// Get service launch protection.
     /// This is a security feature that allows the service to run in a more secure environment.
     pub fn get_launch_protected(&self) -> crate::Result<ServiceLaunchProtected> {
-        let mut data = vec![0u8; std::mem::size_of::<Services::SERVICE_LAUNCH_PROTECTED_INFO>()];
+        let mut data = [0u8; std::mem::size_of::<Services::SERVICE_LAUNCH_PROTECTED_INFO>()];
         unsafe {
             let raw_data: Services::SERVICE_LAUNCH_PROTECTED_INFO = self
                 .query_config2(Services::SERVICE_CONFIG_LAUNCH_PROTECTED, &mut data)
                 .map_err(Error::Winapi)?;
-            ServiceLaunchProtected::from_raw(raw_data.dwLaunchProtected)
+            raw_data.dwLaunchProtected.try_into()
         }
     }
 


### PR DESCRIPTION
Adds launch-protection support to the crate. 
A new **ServiceLaunchProtected** enum (wrapping the four SERVICE_LAUNCH_PROTECTED_* constants) is introduced together with the public helpers Service::set_launch_protected and Service::get_launch_protected, which use SERVICE_CONFIG_LAUNCH_PROTECTED internally. The change is purely additive and does not modify existing APIs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/138)
<!-- Reviewable:end -->
