### PR TITLE
Add `SERVICE_PKG_SERVICE` service type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `OWN_PKG_PROCESS` service type.
 
 
 ## [0.8.1] - 2026-05-08

--- a/src/service.rs
+++ b/src/service.rs
@@ -46,6 +46,9 @@ bitflags::bitflags! {
 
         /// The service can be interactive.
         const INTERACTIVE_PROCESS = SystemServices::SERVICE_INTERACTIVE_PROCESS;
+
+        /// Packaged Service that runs in its own process.
+        const OWN_PKG_PROCESS = SystemServices::SERVICE_PKG_SERVICE;
     }
 }
 


### PR DESCRIPTION
Added `SERVICE_PKG_SERVICE` type in `windows_service::service`. The service type indicates that the service is packaged Win32 own service installed by packaging tools like [MSIX](https://learn.microsoft.com/en-us/windows/msix/app-installer/install-update-app-installer).

This is defined in `winnt.h`:

```c
#define SERVICE_PKG_SERVICE            0x00000200

#define SERVICE_TYPE_ALL               (SERVICE_WIN32  | \
                                        SERVICE_ADAPTER | \
                                        SERVICE_DRIVER  | \
                                        SERVICE_INTERACTIVE_PROCESS | \
                                        SERVICE_USER_SERVICE | \
                                        SERVICE_USERSERVICE_INSTANCE | \
                                        SERVICE_PKG_SERVICE)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/140)
<!-- Reviewable:end -->
