### PR TITLE
Fix clippy format inlining

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,13 +209,11 @@ impl std::fmt::Display for Error {
             Self::LaunchArgumentsNotSupported => {
                 write!(f, "kernel drivers do not support launch arguments")
             }
-            Self::ParseValue(name, _) => write!(f, "invalid {} value", name),
-            Self::ArgumentHasNulByte(name) => write!(f, "{} contains a nul byte", name),
-            Self::ArgumentArrayElementHasNulByte(name, index) => write!(
-                f,
-                "{} contains a nul byte in element at {} index",
-                name, index
-            ),
+            Self::ParseValue(name, _) => write!(f, "invalid {name} value"),
+            Self::ArgumentHasNulByte(name) => write!(f, "{name} contains a nul byte"),
+            Self::ArgumentArrayElementHasNulByte(name, index) => {
+                write!(f, "{name} contains a nul byte in element at {index} index",)
+            }
             Self::Winapi(_) => write!(f, "IO error in winapi call"),
         }
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1943,13 +1943,13 @@ impl std::fmt::Display for ParseRawError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::InvalidInteger(u) => {
-                write!(f, "invalid unsigned integer for the target type: {}", u)
+                write!(f, "invalid unsigned integer for the target type: {u}")
             }
             Self::InvalidIntegerSigned(i) => {
-                write!(f, "invalid signed integer for the target type: {}", i)
+                write!(f, "invalid signed integer for the target type: {i}")
             }
             Self::InvalidGuid(guid) => {
-                write!(f, "invalid GUID value for the target type: {}", guid)
+                write!(f, "invalid GUID value for the target type: {guid}")
             }
         }
     }


### PR DESCRIPTION
Updated error message formatting in Display implementations to use Rust's inline formatting syntax (e.g., {name}) instead of positional arguments.

This fixes recent CI failure: https://github.com/mullvad/windows-service-rs/actions/runs/16498547858/job/46650433128?pr=140

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-service-rs/141)
<!-- Reviewable:end -->
